### PR TITLE
Added snap section to enable snap package creation.

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -31,6 +31,17 @@ linux:
   fileAssociations:
     - ext: "pdf"
 
+snap:
+  confinement: "strict"
+  grade: "devel"
+  stagePackages: [
+  "default"
+  ]
+  plugs: [
+  "default"
+  ]
+
+
 nsis:
   artifactName: ${name}-${version}-${arch}.${ext}
 


### PR DESCRIPTION
I did some reading on the configuration for snap package enablement. These changes should reflect a normal default setting as specified here: https://www.electron.build/configuration/snap.

Unfortunately I could not get electron-builder to run on my machine so please BE CAREFUL AND TEST THIS BRANCH LOCALLY before pulling into master.