### PR TITLE
Don't open a new window on every Dock icon click

### DIFF
--- a/web/js/apps/main/MainApp.ts
+++ b/web/js/apps/main/MainApp.ts
@@ -152,12 +152,14 @@ export class MainApp {
 
         });
 
-        app.on('activate', async function() {
+        app.on('activate', async function(event, hasVisibleWindows) {
 
             // On OS X it's common to re-create a window in the app when the
             // dock icon is clicked and there are no other windows open.
 
-            await MainAppBrowserWindowFactory.createWindow();
+            if (!hasVisibleWindows) {
+              await MainAppBrowserWindowFactory.createWindow();
+            }
 
         });
 


### PR DESCRIPTION
This should resolve #238.
The current behavior:
1. If there are no visible windows, the Document Repository
window is shown.
2. If there is a visible window, the Dock icon does nothing.

API reference https://electronjs.org/docs/api/app#event-activate