### PR TITLE
Limit double clicks to Title column instead of whole row

### DIFF
--- a/apps/repository/js/App.tsx
+++ b/apps/repository/js/App.tsx
@@ -316,10 +316,6 @@ export default class App extends React.Component<AppProps, AppState> {
                                 this.highlightRow(rowInfo.index as number);
                             },
 
-                            onDoubleClick: (e: any) => {
-                                this.onDocumentLoadRequested(rowInfo.original.fingerprint, rowInfo.original.filename);
-                            },
-
                             style: {
                                 background: rowInfo && rowInfo.index === this.state.selected ? '#00afec' : 'white',
                                 color: rowInfo && rowInfo.index === this.state.selected ? 'white' : 'black',
@@ -327,6 +323,13 @@ export default class App extends React.Component<AppProps, AppState> {
                         };
                     }}
                     getTdProps={(state: any, rowInfo: any, column: any, instance: any) => {
+                        if (column.id === 'title') {
+                            return {
+                                onDoubleClick: (e: any) => {
+                                    this.onDocumentLoadRequested(rowInfo.original.fingerprint, rowInfo.original.filename);
+                                }
+                            };
+                        }
 
                         if (column.id === 'flagged' || column.id === 'archived') {
 


### PR DESCRIPTION
Fix #292 -  flag/unflag an item too quickly opens the document. This PR proposes a fix that limits double clicks to Title column instead of whole row.

Before
![](https://cl.ly/d0d95b77d4ea/Screen%20Recording%202018-10-19%20at%2003.28%20pm.gif)

After
![](https://cl.ly/3a32d0778a44/Screen%20Recording%202018-10-19%20at%2003.31%20pm.gif)


Thank you @burtonator for the project. I discovered Polar Bookshelf via HN and absolutely loves it.