### PR TITLE
Setup TypedTags to allow / for hierarchical tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ Flashcards can be created by right clicking an annotation and selecting
 "Create Flashcard".  The resulting flashcards are stored as annotations in your 
 repository.
 
+To specify the Anki deck for a document, add a tag starting with `deck:`.  Slashes are used to specify subdecks.
+For instance, to set a document to the Anki deck ML::100PageMLBook, use the Polar tag `deck:ML/100PageMLBook`.
+
+
 ## Status
 
 This is currently a beta feature and we're working on implementing Anki sync

--- a/web/js/apps/sync/framework/anki/AnkiSyncEngine.ts
+++ b/web/js/apps/sync/framework/anki/AnkiSyncEngine.ts
@@ -102,9 +102,8 @@ export class AnkiSyncEngine implements SyncEngine {
                 .map(tag => Tags.parseTypedTag(tag.label))
                 .filter(typedTag => typedTag.isPresent())
                 .map(typedTag => typedTag.get())
-                .map(typedTag => typedTag.value)
+                .map(typedTag => typedTag.value.join("::"))
                 .pop();
-
         }
 
         if (! deckName) {

--- a/web/js/apps/sync/framework/anki/AnkiSyncEngine.ts
+++ b/web/js/apps/sync/framework/anki/AnkiSyncEngine.ts
@@ -102,7 +102,7 @@ export class AnkiSyncEngine implements SyncEngine {
                 .map(tag => Tags.parseTypedTag(tag.label))
                 .filter(typedTag => typedTag.isPresent())
                 .map(typedTag => typedTag.get())
-                .map(typedTag => typedTag.value.replace("/\//g", "::"))
+                .map(typedTag => typedTag.value.replace(/\//g, "::"))
                 .pop();
         }
 

--- a/web/js/apps/sync/framework/anki/AnkiSyncEngine.ts
+++ b/web/js/apps/sync/framework/anki/AnkiSyncEngine.ts
@@ -102,7 +102,7 @@ export class AnkiSyncEngine implements SyncEngine {
                 .map(tag => Tags.parseTypedTag(tag.label))
                 .filter(typedTag => typedTag.isPresent())
                 .map(typedTag => typedTag.get())
-                .map(typedTag => typedTag.value.join("::"))
+                .map(typedTag => typedTag.value.replace("/\//g", "::"))
                 .pop();
         }
 

--- a/web/js/tags/Tags.ts
+++ b/web/js/tags/Tags.ts
@@ -106,6 +106,7 @@ export class Tags {
      * We support foo:bar values in tags so that we can have typed tags.
      * For example: type:book or deck:fun or something along those lines.
      *
+     * We also support / to denote hierarchy, like deck:main/sub
      */
     public static stripTypedLabel(label: string): Optional<string> {
 
@@ -115,8 +116,15 @@ export class Tags {
             return Optional.empty();
         }
 
-        return Optional.of(label.replace(/^#([^:/]+):([^:]+)$/g, '#$1$2'));
+        // Remove any single lonely slashes
+        const noslashes = label.replace(/([^\/])\/([^\/])/g, '$1$2');
 
+        // If there are any slashes left, we don't like it.
+        if (noslashes.match(/\//g)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(noslashes.replace(/^#([^:/]+):([^:]+)$/g, '#$1$2'));
     }
 
     public static parseTypedTag(value: string): Optional<TypedTag> {
@@ -126,10 +134,8 @@ export class Tags {
 
         return Optional.of({
             name: split[0],
-            value: split[1]
+            value: split[1].split("/")
         });
-
     }
-
 }
 

--- a/web/js/tags/Tags.ts
+++ b/web/js/tags/Tags.ts
@@ -134,7 +134,7 @@ export class Tags {
 
         return Optional.of({
             name: split[0],
-            value: split[1].split("/")
+            value: split[1]
         });
     }
 }

--- a/web/js/tags/TagsTest.ts
+++ b/web/js/tags/TagsTest.ts
@@ -58,9 +58,26 @@ describe('type tags', function() {
         assert.equal(Tags.stripTypedLabel("#:bar").get(), "#:bar");
         assert.equal(Tags.stripTypedLabel("#bar:").get(), "#bar:");
 
-        assert.ok(! Tags.stripTypedLabel("#bar:cat:dog").isPresent());
+        assert.equal(Tags.stripTypedLabel("#foo/bar").get(), "#foobar");
+        assert.equal(Tags.stripTypedLabel("#foo/bar/blah").get(), "#foobarblah");
 
+        assert.equal(Tags.stripTypedLabel("#base:foo/bar").get(), "#basefoobar");
+        assert.equal(Tags.stripTypedLabel("#base:foo/bar/blah").get(), "#basefoobarblah");
+    });
+
+    it("don't allow multiple colons", function() {
+        assert.ok(! Tags.stripTypedLabel("#bar:cat:dog").isPresent());
+        });
+
+    it("don't allow multi slashes", function() {
+        assert.ok(! Tags.stripTypedLabel("#bar//dog").isPresent());
+        assert.ok(! Tags.stripTypedLabel("#//dog").isPresent());
+        assert.ok(! Tags.stripTypedLabel("#dog//").isPresent());
+        assert.ok(! Tags.stripTypedLabel("#//").isPresent());
+        assert.ok(! Tags.stripTypedLabel("#bar///dog").isPresent());
+        assert.ok(! Tags.stripTypedLabel("#///dog").isPresent());
+        assert.ok(! Tags.stripTypedLabel("#dog///").isPresent());
+        assert.ok(! Tags.stripTypedLabel("#///").isPresent());
     });
 
 });
-

--- a/web/js/tags/TypedTag.ts
+++ b/web/js/tags/TypedTag.ts
@@ -9,7 +9,7 @@ export interface TypedTag {
 
     /**
      */
-    readonly value: string[];
+    readonly value: string;
 
 }
 

--- a/web/js/tags/TypedTag.ts
+++ b/web/js/tags/TypedTag.ts
@@ -9,7 +9,7 @@ export interface TypedTag {
 
     /**
      */
-    readonly value: string;
+    readonly value: string[];
 
 }
 


### PR DESCRIPTION
Use hierarchical tags for Anki subdecks.  Add to README.  Add tests.

@burtonator please note I do not know Javascript or TypeScript well, so I may have made egregious mistakes. On the other hand, it appears to work for me.  I can sync into an Anki subdeck.  Feel free to accept or modify or reject--I won't be offended regardless.  Thanks for all your hard work.