### PR TITLE
snap: use xwayland and improve gtk theming

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -65,7 +65,6 @@ win:
   publisherName: Spinn3r
 
 snap:
-
   confinement: "strict"
   grade: "stable"
   stagePackages:
@@ -75,6 +74,12 @@ snap:
     - home
     #- "X11"
     #- "wayland"
+    # additional plugs to pick up the GTK theme and icons from the system, mouse cursor theme still not fixed
+    - { "gtk-3-themes": { "interface": "content", "target": "$SNAP/data-dir/themes", "default-provider": "gtk-common-themes:gtk-3-themes" }, }
+    - { "icon-themes": { "interface": "content", "target": "$SNAP/data-dir/icons", "default-provider": "gtk-common-themes:icon-themes" }, }
+    - { "sound-themes": { "interface": "content", "target": "$SNAP/data-dir/sounds", "default-provider": "gtk-common-themes:sounds-themes" }, }
+  environment:
+    DISABLE_WAYLAND: 1 #use XWayland
 
 # https://www.electron.build/configuration/publish
 # https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/


### PR DESCRIPTION
Related issue #629.

This sets the snap to use XWayland until electron supports wayland natively, otherwise the app crashes in a wayland session.

Additionally some plugs are connected to improve the GTK theme integration, for example, currently the file chooser dialog is using the wrong theme (adwaita instead of Yaru/Ambiance under Ubuntu) and the icons for the folders and button actions are missing. The fallback mouse cursor theme shown in snapped electron apps still remains unresolved.

Screenshots and examples can be found [here](https://github.com/vladimiry/ElectronMail/pull/109).