### PR TITLE
Don't create pagemarks at page end. Fixes #620.

### DIFF
--- a/web/js/metadata/Pagemarks.ts
+++ b/web/js/metadata/Pagemarks.ts
@@ -112,7 +112,7 @@ export class Pagemarks {
 
             }
 
-            if (pagemarks.map(pagemark => pagemark.percentage)
+            if (top === 100 || pagemarks.map(pagemark => pagemark.percentage)
                          .reduce(Reducers.SUM, 0) === 100) {
 
                 // if this page is completely covered just ignore it
@@ -299,6 +299,13 @@ export class Pagemarks {
             }
 
         });
+
+        for (const key of Object.keys(result)) {
+            if (result[key].rect.top === 100) {
+                //log.debug("Invalid pagemark: begins at end of page.", result[key]);
+                delete result[key];
+            }
+        }
 
         return result;
 


### PR DESCRIPTION
If a pagemark that ends at the bottom of the page is resized so it
begins below the top, using "create pagemark at point" on a following
page will create a zero-height pagemark on the page and later fail when
the reading progress has multiple pagemarks with percentage 100.

This commit both prevents the creation of such pagemarks and deletes any
existing pagemarks that begin at the end of the page.