### PR TITLE
Follow symlink in Linux entrypoint

### DIFF
--- a/electron-builder-afterpack.js
+++ b/electron-builder-afterpack.js
@@ -92,7 +92,9 @@ exports.default = async function(context) {
     fs.renameSync(pathPolarBookshelf, pathPolarBookshelfBin);
 
     const wrapperScript = `#!/bin/bash
-    "\${BASH_SOURCE%/*}"/polar-bookshelf.bin "$@" --no-sandbox
+    SOURCE_FILE=$(readlink -f "\${BASH_SOURCE}")
+    SOURCE_DIR=\${SOURCE_FILE%/*}
+    "\${SOURCE_DIR}/polar-bookshelf.bin" "$@" --no-sandbox
   `;
 
     fs.writeFileSync(pathPolarBookshelf, wrapperScript);


### PR DESCRIPTION
`polar-bookshelf-1.19.6-amd64.deb` behavior:

```sh
$ ls /usr/local/bin/polar-bookshelf -laht
lrwxrwxrwx 1 root root 36 May 19 10:30 /usr/local/bin/polar-bookshelf -> '/opt/Polar Bookshelf/polar-bookshelf'
$ polar-bookshelf
/usr/local/bin/polar-bookshelf: line 2: /usr/local/bin/polar-bookshelf.bin: No such file or directory
```

After my changes it works correctly.

Let me know if I need to adjust anything.