### PR TITLE
Update PDF.js version to 2.2.228.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14354,9 +14354,9 @@
       }
     },
     "pdfjs-dist": {
-      "version": "2.0.943",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.0.943.tgz",
-      "integrity": "sha512-iLhNcm4XceTHRaSU5o22ZGCm4YpuW5+rf4+BJFH/feBhMQLbCGBry+Jet8Q419QDI4qgARaIQzXuiNrsNWS8Yw==",
+      "version": "2.2.228",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.2.228.tgz",
+      "integrity": "sha512-W5LhYPMS2UKX0ELIa4u+CFCMoox5qQNQElt0bAK2mwz1V8jZL0rvLao+0tBujce84PK6PvWG36Nwr7agCCWFGQ==",
       "requires": {
         "node-ensure": "^0.0.0",
         "worker-loader": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "node-fetch": "~2.3.0",
     "npm": "~6.5.0",
     "opencollective-postinstall": "~2.0.1",
-    "pdfjs-dist": "~2.0.943",
+    "pdfjs-dist": "~2.2.228",
     "polar-loader": "1.0.3",
     "polar-shared": "^2.0.11",
     "popper.js": "~1.14.4",


### PR DESCRIPTION
I've got a problem loading certain PDF file using version 1.31.1. I've tried to update to the newer version of PDF.js and it worked so I decided to make a PR. I'm not sure if it doesn't break anything though - how can I ensure that, @burtonator?
