### PR TITLE
Convert underscores in tag name to spaces when syncing to Anki

### DIFF
--- a/web/js/apps/sync/framework/anki/Decks.ts
+++ b/web/js/apps/sync/framework/anki/Decks.ts
@@ -9,7 +9,7 @@ export class Decks {
      * @param tagValue
      */
     public static toSubDeck(tagValue: string): string {
-        return tagValue.replace(/\//g, "::");
+        return tagValue.replace(/\//g, "::").replace(/_/g, " ");
     }
 
 }


### PR DESCRIPTION
Currently there is no way to sync cards in a document to an Anki deck with a name that includes spaces, for instance "Spanish Verbs". This solves this by converting underscores in a tag for a document to spaces in the Anki deck name. For instance, tagging a document "deck:Spanish/Spanish_Verbs", will now sync all flashcards from that deck to the Anki deck "Spanish::Spanish Verbs"