### PR TITLE
Fixed download link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ research which is often stored as PDF.
 
 # [Downloads](https://getpolarized.io/download.html)
 
-Packages for Windows, MacOS, and Linux are available on the [downloads](https://getpolarized.io/download.html) page.
+Packages for Windows, MacOS, and Linux are available on the [downloads](https://getpolarized.io/download) page.
 
 We also have a [CHANGELOG](./docs/CHANGELOG.md) available if you're interested into what went into each release.
 


### PR DESCRIPTION
I corrected the link to the downloads page from [https://getpolarized.io/download.html](https://getpolarized.io/download.html) to [https://getpolarized.io/download](https://getpolarized.io/download)