### PR TITLE
Fix issue where area highlights do not work properly with multiple documents open

### DIFF
--- a/apps/doc/src/annotations/AreaHighlightRenderers.ts
+++ b/apps/doc/src/annotations/AreaHighlightRenderers.ts
@@ -28,9 +28,9 @@ export namespace AreaHighlightRenderers {
 
         Preconditions.assertPresent(fileType, 'fileType');
 
-        const rect = AnnotationRects.createFromPointWithinPageElement(pageNum, pointWithinPageElement);
+        const rect = AnnotationRects.createFromPointWithinPageElement(pageNum, pointWithinPageElement, docViewerElement);
 
-        const pageDimensions = getPageElementDimensions(pageNum);
+        const pageDimensions = getPageElementDimensions(pageNum, docViewerElement);
 
         if (! pageDimensions) {
             throw new Error("No page dimensions");
@@ -65,9 +65,9 @@ export namespace AreaHighlightRenderers {
                                                              docViewerElement: HTMLElement): Promise<ICapturedAreaHighlight> {
         Preconditions.assertPresent(fileType, 'fileType');
 
-        const rect = AnnotationRects.createFromOverlayRect(pageNum, overlayRect);
+        const rect = AnnotationRects.createFromOverlayRect(pageNum, overlayRect, docViewerElement);
 
-        const pageDimensions = getPageElementDimensions(pageNum);
+        const pageDimensions = getPageElementDimensions(pageNum, docViewerElement);
 
         if (! pageDimensions) {
             throw new Error("No page dimensions");

--- a/web/js/metadata/AnnotationRects.ts
+++ b/web/js/metadata/AnnotationRects.ts
@@ -31,13 +31,13 @@ export namespace AnnotationRects {
 
     }
 
-    export function getPageElement(page: number): HTMLElement | undefined {
-        return document.querySelectorAll(".page")[page - 1] as HTMLElement || undefined;
+    export function getPageElement(page: number, docViewerElem: HTMLElement): HTMLElement | undefined {
+        return docViewerElem.querySelectorAll(".page")[page - 1] as HTMLElement || undefined;
     }
 
-    export function getPageElementDimensions(page: number): IDimensions | undefined {
+    export function getPageElementDimensions(page: number, docViewerElem: HTMLElement): IDimensions | undefined {
 
-        const pageElement = getPageElement(page);
+        const pageElement = getPageElement(page, docViewerElem);
 
         if (! pageElement) {
             return undefined;
@@ -47,9 +47,9 @@ export namespace AnnotationRects {
 
     }
 
-    export function createFromPointWithinPageElement(pageNum: number, pointWithinPageElement: IPoint) {
+    export function createFromPointWithinPageElement(pageNum: number, pointWithinPageElement: IPoint, docViewerElem: HTMLElement) {
 
-        const pageElement = getPageElement(pageNum);
+        const pageElement = getPageElement(pageNum, docViewerElem);
 
         if (pageElement) {
             const containerDimensions = computeContainerDimensions(pageElement);
@@ -60,9 +60,9 @@ export namespace AnnotationRects {
 
     }
 
-    export function createFromOverlayRect(pageNum: number, overlayRect: ILTRect) {
+    export function createFromOverlayRect(pageNum: number, overlayRect: ILTRect, docViewerElem: HTMLElement) {
 
-        const pageElement = getPageElement(pageNum);
+        const pageElement = getPageElement(pageNum, docViewerElem);
 
         if (pageElement) {
             const containerDimensions = computeContainerDimensions(pageElement);


### PR DESCRIPTION
Changelog:
- Change the definition of `getPageElement` & `getPageElementDimensions` to accept a second argument which is the container of the document that has the highlight being created.