### PR TITLE
Alllow jumping to annotations using hash on document load

### DIFF
--- a/apps/doc/src/DocViewerAnnotationHook.ts
+++ b/apps/doc/src/DocViewerAnnotationHook.ts
@@ -26,8 +26,8 @@ export function useDocViewerJumpToPageLoader(): (location: ILocation, cause: Doc
 
                 try {
 
-                    if (prevPageRef.current !== annotationLink.page
-                        || prevNonceRef.current !== annotationLink.nonce) {
+                    if (prevPageRef.current !== annotationLink.page ||
+                        prevNonceRef.current !== annotationLink.nonce) {
 
                         console.log(`Jumping to page ${annotationLink.page} due to '${cause}'`);
                         onPageJump(annotationLink.page);

--- a/apps/doc/src/DocViewerAnnotationHook.ts
+++ b/apps/doc/src/DocViewerAnnotationHook.ts
@@ -26,13 +26,12 @@ export function useDocViewerJumpToPageLoader(): (location: ILocation, cause: Doc
 
                 try {
 
-                    if (
-                        prevPageRef.current !== annotationLink.page
-                        || prevNonceRef.current !== annotationLink.nonce
-                    ) {
+                    if (prevPageRef.current !== annotationLink.page
+                        || prevNonceRef.current !== annotationLink.nonce) {
 
                         console.log(`Jumping to page ${annotationLink.page} due to '${cause}'`);
                         onPageJump(annotationLink.page);
+                        return true;
                     }
                 } finally {
                     prevPageRef.current = annotationLink.page;
@@ -78,7 +77,8 @@ export function useDocViewerPageJumpListener() {
     }
     const isViewerVisible = useDocumentViewerVisible(docMeta.docInfo.fingerprint);
     React.useEffect(() => {
-        if (isViewerVisible)
+        if (isViewerVisible) {
             docViewerJumpToPageLoader(location, 'history');
+        }
     }, [location, isViewerVisible, docViewerJumpToPageLoader]);
 }

--- a/apps/doc/src/DocViewerAnnotationHook.ts
+++ b/apps/doc/src/DocViewerAnnotationHook.ts
@@ -1,10 +1,11 @@
 import {useLocation} from "react-router-dom";
-import {useDocViewerCallbacks} from "./DocViewerStore";
+import {useDocViewerCallbacks, useDocViewerStore} from "./DocViewerStore";
 import {AnnotationLinks} from "../../../web/js/annotation_sidebar/AnnotationLinks";
 import {ILocation} from "../../../web/js/react/router/ReactRouters";
 import React from 'react';
 import {useDocViewerContext} from "./renderers/DocRenderer";
 import {DocViewerAppURLs} from "./DocViewerAppURLs";
+import {useDocumentViewerVisible} from "./renderers/UseSidenavDocumentChangeCallbackHook";
 
 export type DocViewerJumpCause = 'init' | 'history';
 
@@ -12,6 +13,7 @@ export function useDocViewerJumpToPageLoader(): (location: ILocation, cause: Doc
 
     const {onPageJump} = useDocViewerCallbacks();
     const prevPageRef = React.useRef<number | undefined>();
+    const prevNonceRef = React.useRef<string | undefined>();
     const currentDocumentLocationPredicate = useCurrentDocumentLocationPredicate();
 
     return (location, cause) => {
@@ -24,16 +26,17 @@ export function useDocViewerJumpToPageLoader(): (location: ILocation, cause: Doc
 
                 try {
 
-                    if (prevPageRef.current !== annotationLink.page) {
+                    if (
+                        prevPageRef.current !== annotationLink.page
+                        || prevNonceRef.current !== annotationLink.nonce
+                    ) {
 
                         console.log(`Jumping to page ${annotationLink.page} due to '${cause}'`);
                         onPageJump(annotationLink.page);
-                        return true;
-
                     }
-
                 } finally {
                     prevPageRef.current = annotationLink.page;
+                    prevNonceRef.current = annotationLink.nonce;
                 }
 
             }
@@ -69,5 +72,13 @@ function useCurrentDocumentLocationPredicate() {
 export function useDocViewerPageJumpListener() {
     const location = useLocation();
     const docViewerJumpToPageLoader = useDocViewerJumpToPageLoader();
-    docViewerJumpToPageLoader(location, 'history');
+    const {docMeta} = useDocViewerStore(['docMeta']);
+    if (!docMeta) {
+        throw new Error("No docMeta");
+    }
+    const isViewerVisible = useDocumentViewerVisible(docMeta.docInfo.fingerprint);
+    React.useEffect(() => {
+        if (isViewerVisible)
+            docViewerJumpToPageLoader(location, 'history');
+    }, [location, isViewerVisible, docViewerJumpToPageLoader]);
 }

--- a/apps/doc/src/annotations/ScrollIntoViewUsingLocation.tsx
+++ b/apps/doc/src/annotations/ScrollIntoViewUsingLocation.tsx
@@ -19,7 +19,7 @@ export function scrollIntoView(scrollTarget: IScrollTarget, ref: HTMLElement) {
 
 export function useScrollIntoViewUsingLocation() {
 
-    const ref = React.useRef<HTMLElement | null>(null);
+    const [scrollTargetElem, setScrollTargetElem] = React.useState<HTMLElement | null>(null);
     const {initialScrollLoader} = useLocationChangeStore(['initialScrollLoader'])
     const scrollTarget = useScrollTarget();
 
@@ -29,19 +29,16 @@ export function useScrollIntoViewUsingLocation() {
     //
     // - when the scrollTarget has changed due to a location change.
 
-    function handleRef() {
-        if (scrollTarget && ref.current) {
-            initialScrollLoader(scrollTarget, ref.current);
+    React.useEffect(() => {
+        if (scrollTarget && scrollTargetElem) {
+            initialScrollLoader(scrollTarget, scrollTargetElem);
         }
-    }
-
-    handleRef();
+    }, [scrollTarget, scrollTargetElem, initialScrollLoader]);
 
     return (newRef: HTMLElement | null) => {
 
-        if (ref.current !== newRef) {
-            ref.current = newRef;
-            handleRef();
+        if (scrollTargetElem !== newRef) {
+            setScrollTargetElem(newRef);
         }
 
     }

--- a/apps/doc/src/renderers/DocumentInitHook.tsx
+++ b/apps/doc/src/renderers/DocumentInitHook.tsx
@@ -19,6 +19,9 @@ export function useDocumentInit() {
     const [resumeProgressActive, resumeProgressHandler] = useReadingProgressResume();
 
     const doInit = React.useCallback(() => {
+        if (document.location.hash.length !== 0) {
+            return;
+        }
 
         if (! pageNavigator) {
             throw new Error("No pageNavigator");

--- a/apps/doc/src/renderers/pdf/PDFDocument.tsx
+++ b/apps/doc/src/renderers/pdf/PDFDocument.tsx
@@ -150,8 +150,6 @@ export const PDFDocument = deepMemo(function PDFDocument(props: IProps) {
     const prefs = usePrefsContext();
     const annotationBarInjector = useAnnotationBar();
 
-    useDocViewerPageJumpListener();
-
     const hasPagesInitRef = React.useRef(false);
     const hasLoadRef = React.useRef(false);
 

--- a/apps/repository/js/login/Authenticator.tsx
+++ b/apps/repository/js/login/Authenticator.tsx
@@ -376,7 +376,7 @@ const EmailTokenAuthButton = () => {
                                        variant="outlined" />
 
                             <div className={classes.alternate}>
-                                <Button onClick={handleEmailProvided}>Didn't receive email</Button>
+                                <Button onClick={handleEmailProvided}>Resend Email</Button>
                             </div>
                             <Button variant="contained"
                                     color="primary"

--- a/web/js/annotation_sidebar/AnnotationLinks.ts
+++ b/web/js/annotation_sidebar/AnnotationLinks.ts
@@ -28,14 +28,16 @@ export namespace AnnotationLinks {
     export interface IAnnotationLink {
         readonly page: number;
         readonly target: string;
+        readonly nonce?: string;
     }
 
-    export function parse(queryOrLocation: QueryOrLocation): IAnnotationLink | undefined{
+    export function parse(queryOrLocation: QueryOrLocation): IAnnotationLink | undefined {
 
         const params = HashURLs.parse(queryOrLocation);
 
         const page = Optional.of(params.get('page')).map(parseInt).getOrUndefined();
         const target = params.get('target') || undefined;
+        const nonce = params.get('n') || undefined;
 
         if (page === undefined && target === undefined) {
             return undefined;
@@ -43,7 +45,8 @@ export namespace AnnotationLinks {
 
         return {
             page: page!,
-            target: target!
+            target: target!,
+            nonce,
         };
 
     }

--- a/web/js/annotation_sidebar/AnnotationViewControlBar2.tsx
+++ b/web/js/annotation_sidebar/AnnotationViewControlBar2.tsx
@@ -24,6 +24,7 @@ import FlashAutoIcon from '@material-ui/icons/FlashAuto';
 import {useAutoFlashcardHandler} from "./AutoFlashcardHook";
 import {useAIFlashcardVerifiedAction} from "../../../apps/repository/js/ui/AIFlashcardVerifiedAction";
 import {useTheme} from "@material-ui/core";
+import {useAnnotationLink} from './JumpToAnnotationHook';
 
 const useStyles = makeStyles((theme) =>
     createStyles({
@@ -154,6 +155,8 @@ export const AnnotationViewControlBar2 = React.memo((props: IProps) => {
         selected: [annotation]
     });
 
+    const annotationLink = useAnnotationLink(annotation);
+
     return (
 
         <>
@@ -166,8 +169,7 @@ export const AnnotationViewControlBar2 = React.memo((props: IProps) => {
 
                         <DocAuthor author={annotation.author}/>
 
-                        <MUIAnchor href="#"
-                                   onClick={NULL_FUNCTION}>
+                        <MUIAnchor href={annotationLink}>
                             <DocAnnotationMoment created={annotation.lastUpdated}/>
                         </MUIAnchor>
 

--- a/web/js/annotation_sidebar/buttons/JumpToAnnotationButton.tsx
+++ b/web/js/annotation_sidebar/buttons/JumpToAnnotationButton.tsx
@@ -3,9 +3,8 @@ import {memoForwardRef} from "../../react/ReactUtils";
 import {AnnotationType} from 'polar-shared/src/metadata/AnnotationType';
 import {IDocAnnotationRef} from "../DocAnnotation";
 import CenterFocusStrongIcon from '@material-ui/icons/CenterFocusStrong';
-import {useJumpToAnnotationHandler} from "../JumpToAnnotationHook";
+import {createAnnotationPointer, useJumpToAnnotationHandler} from "../JumpToAnnotationHook";
 import {StandardIconButton} from "../../../../apps/repository/js/doc_repo/buttons/StandardIconButton";
-import {AnnotationPtrs, IAnnotationPtr} from "../AnnotationPtrs";
 
 
 interface IProps {
@@ -20,15 +19,9 @@ export const JumpToAnnotationButton = memoForwardRef((props: IProps) => {
 
     const handleJumpToCurrentAnnotation = React.useCallback(() => {
 
-        const ptr: IAnnotationPtr = AnnotationPtrs.create({
-            target: annotation.id,
-            pageNum: annotation.pageNum,
-            docID: annotation.docMetaRef.id,
-        });
+        jumpToAnnotationHandler(createAnnotationPointer(annotation));
 
-        jumpToAnnotationHandler(ptr);
-
-    }, [annotation.docMetaRef.id, annotation.id, annotation.pageNum, jumpToAnnotationHandler]);
+    }, [annotation, jumpToAnnotationHandler]);
 
     if (! [AnnotationType.TEXT_HIGHLIGHT, AnnotationType.AREA_HIGHLIGHT].includes(annotation.annotationType)) {
         // this should only be added on text highlights.

--- a/web/js/apps/main/doc_loaders/LoadDocRequest.ts
+++ b/web/js/apps/main/doc_loaders/LoadDocRequest.ts
@@ -11,6 +11,11 @@ export interface LoadDocRequest {
      */
     readonly url: string | undefined;
 
+    /**
+     * Used for jumping to specific areas in the document upon load
+     */
+    readonly initialUrl?: string;
+
     readonly backendFileRef: BackendFileRef;
 
     /**

--- a/web/js/apps/main/doc_loaders/sidenav/SideNavDocLoaders.ts
+++ b/web/js/apps/main/doc_loaders/sidenav/SideNavDocLoaders.ts
@@ -42,7 +42,8 @@ export function useSideNavDocLoader() {
                 id: loadDocRequest.fingerprint,
                 url,
                 title: loadDocRequest.title,
-                type
+                type,
+                initialUrl: loadDocRequest.initialUrl,
             })
 
         }

--- a/web/js/sidenav/SideNavInitializer.tsx
+++ b/web/js/sidenav/SideNavInitializer.tsx
@@ -7,6 +7,7 @@ import {BackendFileRefs} from "../datastore/BackendFileRefs";
 import {Either} from "../util/Either";
 import {LoadDocRequest} from "../apps/main/doc_loaders/LoadDocRequest";
 import {IDStr} from "polar-shared/src/util/Strings";
+import {useLocation} from 'react-router';
 
 export function useSideNavInitializer() {
 
@@ -15,7 +16,7 @@ export function useSideNavInitializer() {
     const repoDocMetaManager = useRepoDocMetaManager();
 
     // the initial location of the app...
-    const location = React.useMemo(() => document.location, []);
+    const location = useLocation();
 
     // the first docViewerURL based on the initial location.
     const docViewerURL = DocViewerAppURLs.parse(location.pathname)
@@ -40,13 +41,14 @@ export function useSideNavInitializer() {
                 title: repoDocInfo.title,
                 url: repoDocInfo.url,
                 backendFileRef,
-                newWindow: true
-            }
+                newWindow: true,
+                initialUrl: `${location.pathname}${location.hash}`,
+            };
 
             docLoader(docLoadRequest);
         }
 
-    }, [docLoader, repoDocMetaManager.repoDocInfoIndex])
+    }, [location, docLoader, repoDocMetaManager.repoDocInfoIndex])
 
     React.useEffect(() => {
 


### PR DESCRIPTION
### Changelog:
- Allow jumping to annotations using hash on document load
- Add the ability to click on annotation timestamp to jump to it in its document.