### PR TITLE
Improve pinch to zoom functionality.

### DIFF
--- a/apps/doc/src/renderers/pdf/PDFDocument.tsx
+++ b/apps/doc/src/renderers/pdf/PDFDocument.tsx
@@ -142,7 +142,7 @@ export const PDFDocument = deepMemo(function PDFDocument(props: IProps) {
     const log = useLogger();
 
     const {setDocDescriptor, setPageNavigator, setResizer, setScaleLeveler,
-           setDocScale, setPage, setOutline, setOutlineNavigator, docMetaProvider}
+           setDocScale, setPage, setOutline, setOutlineNavigator, docMetaProvider, setScale: setStoreScale}
         = useDocViewerCallbacks();
 
     const {setFinder} = useDocFindCallbacks();
@@ -224,6 +224,7 @@ export const PDFDocument = deepMemo(function PDFDocument(props: IProps) {
 
         if (['page-width', 'page-fit'].includes(scaleRef.current.value)) {
             setScale(scaleRef.current);
+            setStoreScale(scaleRef.current);
         }
 
         if (docViewerRef.current) {
@@ -232,7 +233,7 @@ export const PDFDocument = deepMemo(function PDFDocument(props: IProps) {
             throw new Error("No viewer");
         }
 
-    }, [setScale]);
+    }, [setScale, setStoreScale]);
 
     const doLoad = React.useCallback(async (docViewer: DocViewer) => {
 

--- a/apps/doc/src/renderers/pdf/PDFViewerContainer.tsx
+++ b/apps/doc/src/renderers/pdf/PDFViewerContainer.tsx
@@ -2,14 +2,14 @@ import * as React from "react";
 import {useContextMenu} from "../../../../repository/js/doc_repo/MUIContextMenu";
 import {Elements} from "../../../../../web/js/util/Elements";
 import {GlobalPDFCss} from "./GlobalPDFCss";
-import {useDocViewerCallbacks, useDocViewerStore} from "../../DocViewerStore";
-import {FakePinchToZoom} from "../../PinchHooks";
+import {usePDFPinchToZoom} from "./PinchToZoomHooks";
 
 let iter: number = 0;
 
 interface IProps {
     readonly children: React.ReactNode;
 }
+
 
 export const PDFViewerContainer = React.memo(function PDFViewerContainer(props: IProps) {
 
@@ -29,31 +29,14 @@ export const PDFViewerContainer = React.memo(function PDFViewerContainer(props: 
     }, [contextMenu]);
 
     const viewerRef = React.useRef<HTMLDivElement>(null);
+    const wrapperRef = React.useRef<HTMLDivElement>(null);
     
-    const {docScale} = useDocViewerStore(['docScale']);
-    const {setScale} = useDocViewerCallbacks()
-
-    const shouldUpdateScale = React.useCallback((zoom: number): boolean => {
-        const min = 0.1, max = 4;
-        const scale = docScale!.scaleValue * zoom;
-        return scale >= min && scale <= max;
-    }, [docScale]);
-
-    const handleZoom = React.useCallback((zoom: number): void => {
-        setScale({ label: `${zoom * 100}%`, value: `${zoom * docScale!.scaleValue}` });
-    }, [docScale, setScale]);
+    usePDFPinchToZoom({ containerRef: viewerRef, wrapperRef: wrapperRef });
 
     ++iter;
 
     return (
         <>
-            {docScale !== undefined && (
-                <FakePinchToZoom
-                    elemRef={viewerRef}
-                    shouldUpdate={shouldUpdateScale}
-                    onZoom={handleZoom}
-                />
-            )}
             <GlobalPDFCss/>
             <div onContextMenu={onContextMenu}
                   id="viewerContainer"
@@ -65,6 +48,7 @@ export const PDFViewerContainer = React.memo(function PDFViewerContainer(props: 
                       height: '100%',
                   }}
                   tabIndex={0}
+                  ref={wrapperRef}
                   className="viewerContainer"
                   itemProp= "mainContentOfPage"
                   data-iter={iter}>

--- a/apps/doc/src/renderers/pdf/PinchToZoomHooks.ts
+++ b/apps/doc/src/renderers/pdf/PinchToZoomHooks.ts
@@ -1,0 +1,85 @@
+import React from "react";
+import {useDocViewerCallbacks, useDocViewerStore} from "../../DocViewerStore";
+import {useFakePinchToZoom} from "../../PinchHooks";
+import {ScaleLevelTuple, ScaleLevelTuples} from "../../ScaleLevels";
+
+type UseElemWidthChangedOpts = {
+    threshold?: number;
+    elemRef: React.RefObject<HTMLElement>;
+};
+
+export const useElemWidthChanged = (callback: () => void, opts: UseElemWidthChangedOpts) => {
+    const {threshold = 5, elemRef} = opts;
+    const oldWidthRef = React.useRef<number>(window.innerWidth);
+    useResizeObserver(React.useCallback(({ contentRect: { width } }) => {
+        if (Math.abs(oldWidthRef.current - width) > threshold) {
+            oldWidthRef.current = width;
+            callback();
+        }
+    }, [oldWidthRef, callback, threshold]), elemRef);
+};
+
+type UseResizeObserverCallback = (entry: ResizeObserverEntry) => void;
+
+export const useResizeObserver = (callback: UseResizeObserverCallback, elemRef: React.RefObject<HTMLElement>) => {
+    const callbackRef = React.useRef<UseResizeObserverCallback>(callback);
+
+    const baseCallback: ResizeObserverCallback = React.useCallback((entries) => {
+        callbackRef.current(entries[0]);
+    }, []);
+
+    React.useEffect(() => {
+        callbackRef.current = callback;
+    }, [callback]);
+
+    React.useEffect(() => {
+        if (!elemRef.current) {
+            return;
+        }
+        const resizeObserver = new ResizeObserver(baseCallback)
+        resizeObserver.observe(elemRef.current);
+        return () => resizeObserver.disconnect();
+    }, [elemRef, baseCallback]);
+};
+
+interface IUsePDFPinchToZoomArgs {
+    containerRef: React.RefObject<HTMLElement>; 
+    wrapperRef: React.RefObject<HTMLElement>; 
+}
+
+export const usePDFPinchToZoom = ({ containerRef, wrapperRef }: IUsePDFPinchToZoomArgs) => {
+    const {docScale} = useDocViewerStore(['docScale']);
+    const {setScale} = useDocViewerCallbacks();
+    const initialScale = React.useRef<number>();
+
+    React.useEffect(() => {
+        if (docScale && docScale?.scale.value === "page-width") {
+            initialScale.current = docScale.scaleValue;
+        }
+    }, [docScale]);
+
+    useElemWidthChanged(() => setScale(ScaleLevelTuples[1]), { elemRef: wrapperRef });
+
+    const shouldUpdate = React.useCallback((zoom: number): boolean => {
+        const min = initialScale.current!, max = 4;
+        const scale = docScale!.scaleValue * zoom;
+        return scale >= min && scale <= max;
+    }, [docScale, initialScale]);
+
+    const onZoom = React.useCallback((zoom: number): void => {
+        const newScale = zoom * docScale!.scaleValue;
+        const newScaleLevel: ScaleLevelTuple = {
+            label: `${Math.round(newScale * 100)}%`,
+            value: `${newScale}`,
+        };
+        setScale(newScaleLevel);
+    }, [docScale, setScale]);
+
+    useFakePinchToZoom({
+        onZoom,
+        shouldUpdate: shouldUpdate,
+        elemRef: containerRef,
+        wrapperRef: wrapperRef,
+        enabled: !! initialScale,
+    });
+};

--- a/apps/doc/src/renderers/pdf/PinchToZoomHooks.ts
+++ b/apps/doc/src/renderers/pdf/PinchToZoomHooks.ts
@@ -63,7 +63,7 @@ export const usePDFPinchToZoom = ({ containerRef, wrapperRef }: IUsePDFPinchToZo
     const shouldUpdate = React.useCallback((zoom: number): boolean => {
         const min = initialScale.current!, max = 4;
         const scale = docScale!.scaleValue * zoom;
-        return scale >= min && scale <= max;
+        return (scale >= min || zoom > 1) && (scale <= max || zoom < 1);
     }, [docScale, initialScale]);
 
     const onZoom = React.useCallback((zoom: number): void => {


### PR DESCRIPTION
Changelog:
- Convert everything into hooks and refactor some code.
- Reset zoom level to 100% (screen width) on resize & device orientation change.
- Account for the doc viewer toolbar when setting the transform-origin.
- Disallow zooming out below screen width.