### PR TITLE
Add area highlight mode

### DIFF
--- a/apps/doc/src/DocViewerGlobalHotKeys.tsx
+++ b/apps/doc/src/DocViewerGlobalHotKeys.tsx
@@ -10,6 +10,7 @@ import useLocationWithPathOnly = ReactRouters.useLocationWithPathOnly;
 import {DocViewerAppURLs} from "./DocViewerAppURLs";
 import {DockLayoutGlobalHotKeys} from "../../../web/js/ui/doc_layout/DockLayoutGlobalHotKeys";
 import {SideNavGlobalHotKeys} from "../../../web/js/sidenav/SideNavGlobalHotKeys";
+import {useRefWithUpdates} from "../../../web/js/hooks/ReactHooks";
 
 const globalKeyMap = keyMapWithGroup({
     group: "Document Viewer",
@@ -62,8 +63,13 @@ const globalKeyMap = keyMapWithGroup({
         ARCHIVE: {
             name: "Archive",
             description: "Archive doc",
-            sequences: ['a']
+            sequences: ['shift+A']
         },
+        TOGGLE_AREA_HIGHLIGHT_MODE: {
+            name: "Area Highlight Mode",
+            description: "Toggle area higlight mode",
+            sequences: ['a'],
+        }
 
     }
 });
@@ -71,7 +77,16 @@ const globalKeyMap = keyMapWithGroup({
 export const DocViewerGlobalHotKeys = React.memo(function DocViewerGlobalHotKeys() {
 
     const findCallbacks = useDocFindCallbacks();
-    const {onPagePrev, onPageNext, doZoom, doZoomRestore, onDocTagged, toggleDocArchived, toggleDocFlagged} = useDocViewerCallbacks();
+    const {
+        onPagePrev,
+        onPageNext,
+        doZoom,
+        doZoomRestore,
+        onDocTagged,
+        toggleDocArchived,
+        toggleDocFlagged,
+        toggleAreaHighlightMode,
+    } = useDocViewerCallbacks();
     const {docMeta} = useDocViewerStore(['docMeta']);
 
     const globalKeyHandlers = {
@@ -85,6 +100,7 @@ export const DocViewerGlobalHotKeys = React.memo(function DocViewerGlobalHotKeys
         TAG: onDocTagged,
         FLAG: toggleDocFlagged,
         ARCHIVE: toggleDocArchived,
+        TOGGLE_AREA_HIGHLIGHT_MODE: toggleAreaHighlightMode,
     };
 
     const location = useLocationWithPathOnly();

--- a/apps/doc/src/DocViewerMenu.tsx
+++ b/apps/doc/src/DocViewerMenu.tsx
@@ -437,7 +437,15 @@ export const DocViewerMenu = (props: MenuComponentProps<IDocViewerContextMenuOri
     const onCreateAreaHighlight = React.useCallback(() => {
         const {pageNum, pointWithinPageElement} = origin;
 
-        onAreaHighlightCreated({pageNum, pointWithinPageElement});
+        onAreaHighlightCreated({
+            pageNum,
+            rectWithinPageElement: {
+                left: pointWithinPageElement.x,
+                top: pointWithinPageElement.y,
+                width: 150,
+                height: 150,
+            },
+        });
 
     }, [onAreaHighlightCreated, origin]);
 

--- a/apps/doc/src/DocViewerStore.tsx
+++ b/apps/doc/src/DocViewerStore.tsx
@@ -135,6 +135,7 @@ export interface IDocViewerStore {
 
     readonly outlineNavigator?: OutlineNavigator;
 
+    readonly areaHighlightModeActive: boolean;
 }
 
 export interface IPagemarkCoverage {
@@ -306,13 +307,15 @@ export interface IDocViewerCallbacks {
 
     readonly setColumnLayout: (columLayout: number) => void;
 
+    readonly setAreaHighlightModeActive: (state: boolean) => void;
 }
 
 const initialStore: IDocViewerStore = {
     page: 1,
     docLoaded: false,
     pendingWrites: 0,
-    fluidPagemarkFactory: new NullFluidPagemarkFactory()
+    fluidPagemarkFactory: new NullFluidPagemarkFactory(),
+    areaHighlightModeActive: false,
 }
 
 interface Mutator {
@@ -998,6 +1001,11 @@ function useCallbacksFactory(storeProvider: Provider<IDocViewerStore>,
             Analytics.event2('doc-columnLayoutChanged', { columns: columnLayout });
         }
 
+        function setAreaHighlightModeActive(state: boolean) {
+            const store = storeProvider();
+            setStore({...store, areaHighlightModeActive: state});
+        }
+
         return {
             updateDocMeta,
             setDocMeta,
@@ -1025,7 +1033,8 @@ function useCallbacksFactory(storeProvider: Provider<IDocViewerStore>,
             setOutline,
             setOutlineNavigator,
             docMetaProvider,
-            setColumnLayout
+            setColumnLayout,
+            setAreaHighlightModeActive,
         };
     }, [log, docMetaContext, persistenceLayerContext, annotationSidebarCallbacks,
         dialogs, annotationMutationCallbacksFactory, setStore, storeProvider]);

--- a/apps/doc/src/DocViewerStore.tsx
+++ b/apps/doc/src/DocViewerStore.tsx
@@ -135,7 +135,7 @@ export interface IDocViewerStore {
 
     readonly outlineNavigator?: OutlineNavigator;
 
-    readonly areaHighlightModeActive: boolean;
+    readonly areaHighlightMode: boolean;
 }
 
 export interface IPagemarkCoverage {
@@ -307,7 +307,7 @@ export interface IDocViewerCallbacks {
 
     readonly setColumnLayout: (columLayout: number) => void;
 
-    readonly setAreaHighlightModeActive: (state: boolean) => void;
+    readonly toggleAreaHighlightMode: () => void;
 }
 
 const initialStore: IDocViewerStore = {
@@ -315,7 +315,7 @@ const initialStore: IDocViewerStore = {
     docLoaded: false,
     pendingWrites: 0,
     fluidPagemarkFactory: new NullFluidPagemarkFactory(),
-    areaHighlightModeActive: false,
+    areaHighlightMode: false,
 }
 
 interface Mutator {
@@ -1001,9 +1001,9 @@ function useCallbacksFactory(storeProvider: Provider<IDocViewerStore>,
             Analytics.event2('doc-columnLayoutChanged', { columns: columnLayout });
         }
 
-        function setAreaHighlightModeActive(state: boolean) {
+        function toggleAreaHighlightMode() {
             const store = storeProvider();
-            setStore({...store, areaHighlightModeActive: state});
+            setStore({...store, areaHighlightMode: !store.areaHighlightMode});
         }
 
         return {
@@ -1034,7 +1034,7 @@ function useCallbacksFactory(storeProvider: Provider<IDocViewerStore>,
             setOutlineNavigator,
             docMetaProvider,
             setColumnLayout,
-            setAreaHighlightModeActive,
+            toggleAreaHighlightMode,
         };
     }, [log, docMetaContext, persistenceLayerContext, annotationSidebarCallbacks,
         dialogs, annotationMutationCallbacksFactory, setStore, storeProvider]);

--- a/apps/doc/src/annotations/AreaHighlightDrawer.tsx
+++ b/apps/doc/src/annotations/AreaHighlightDrawer.tsx
@@ -1,0 +1,221 @@
+import React from "react";
+import {IPoint} from '../../../../web/js/Point';
+import {IRect} from 'polar-shared/src/util/rects/IRect';
+import {ControlledAnnotationBars} from '../../../../web/js/ui/annotationbar/ControlledAnnotationBars';
+import {Elements} from '../../../../web/js/util/Elements';
+import {createStyles, makeStyles} from '@material-ui/core';
+import {useAreaHighlightHooks} from '../annotations/AreaHighlightHooks';
+import {ILTRect} from 'polar-shared/src/util/rects/ILTRect';
+import {useDocViewerCallbacks, useDocViewerStore} from '../DocViewerStore';
+import {useDocViewerElementsContext} from '../renderers/DocViewerElementsContext';
+
+const useAreaHighlightCreatorStyles = makeStyles(() =>
+    createStyles({
+        viewerContainer: {
+            "& .page *, & .page": {
+                cursor: "crosshair!important",
+            },
+        },
+    }),
+);
+
+export const AreaHighlightCreator: React.FC = () => {
+    const {areaHighlightModeActive} = useDocViewerStore(["areaHighlightModeActive"]);
+    const {onAreaHighlightCreated} = useAreaHighlightHooks();
+    const {setAreaHighlightModeActive} = useDocViewerCallbacks();
+    const docViewerElements = useDocViewerElementsContext();
+    const classes = useAreaHighlightCreatorStyles();
+
+    React.useEffect(() => {
+        const viewerContainer = docViewerElements.getDocViewerElement().querySelector("#viewerContainer");
+        if (viewerContainer) {
+            viewerContainer.classList[areaHighlightModeActive ? "add" : "remove"](classes.viewerContainer);
+        }
+    }, [areaHighlightModeActive]);
+
+    const createAreaHighlight = React.useCallback(({ rect, pageNum }) => {
+        onAreaHighlightCreated({ pageNum, rectWithinPageElement: rect });
+        setAreaHighlightModeActive(false);
+    }, [onAreaHighlightCreated, setAreaHighlightModeActive])
+
+    usePDFRectangleDrawer(createAreaHighlight, { enabled: areaHighlightModeActive });
+
+    return null;
+};
+
+type IUsePDFRectangleDrawerCallback = (data: { pageNum: number, rect: ILTRect }) => void;
+type IUsePDFRectangleDrawerOpts = {
+    threshold?: IPoint;
+    enabled?: boolean;
+};
+
+const useStyles = makeStyles(() =>
+    createStyles({
+        viewerContainer: {
+            "& .page *, & .page": {
+                cursor: "crosshair!important",
+            },
+        },
+        rect: {
+            pointerEvents: "none",
+            position: "absolute",
+            zIndex: 10,
+            background: "rgba(255, 255, 0, 0.5)",
+            mixBlendMode: "multiply",
+            border: "1px solid rgb(198, 198, 198)",
+        },
+    }),
+);
+
+const rangeConstrain = (val: number, min: number, max: number) => Math.max(min, Math.min(val, max));
+
+const calculateRectDimensions = (start: IPoint, position: IPoint, pageRect: ClientRect): ILTRect => {
+    const {x, y} = getRelativePosition(position, pageRect);
+    const w = rangeConstrain(x - start.x, -start.x, pageRect.width - start.x);
+    const h = rangeConstrain(y - start.y, -start.y, pageRect.height - start.y);
+    return {
+        top: Math.min(start.y, start.y + h),
+        left: Math.min(start.x, start.x + w),
+        width: Math.abs(w),
+        height: Math.abs(h),
+    };
+};
+
+const getRelativePosition = (position: IPoint, pageRect: IRect): IPoint => ({
+    x: position.x - pageRect.left,
+    y: position.y - pageRect.top,
+});
+
+
+const updateDOMRect = (rectElem: HTMLDivElement, { top, left, width, height }: ILTRect): void => {
+    rectElem.style.top = `${top}px`;
+    rectElem.style.left = `${left}px`;
+    rectElem.style.width = `${width}px`;
+    rectElem.style.height = `${height}px`;
+};
+
+export const usePDFRectangleDrawer = (callback: IUsePDFRectangleDrawerCallback, opts?: IUsePDFRectangleDrawerOpts) => {
+    const {threshold = { x: 20, y: 20 }, enabled = true} = opts || {};
+    const docViewerElements = useDocViewerElementsContext();
+    const classes = useStyles();
+    const callbackRef = React.useRef<IUsePDFRectangleDrawerCallback>(callback);
+    callbackRef.current = callback;
+
+    React.useEffect(() => {
+        if (!enabled) return;
+        let start: IPoint | undefined = undefined;
+        let pageRect: IRect | undefined;
+        let pageElement: HTMLElement | undefined;
+        let rectElem: HTMLDivElement | undefined;
+
+
+        const init = (target: EventTarget | null, position: IPoint): boolean => {
+            if (target && target instanceof HTMLElement) {
+                pageElement = Elements.untilRoot(target, ".page") as HTMLDivElement;
+                if (pageElement) {
+                    rectElem = document.createElement("div");
+                    pageElement.appendChild(rectElem);
+                    pageRect = pageElement.getBoundingClientRect();
+                    const pageStyles = window.getComputedStyle(pageElement);
+                    const border = {
+                        top: +pageStyles.borderTopWidth.slice(0, -2),
+                        left: +pageStyles.borderLeftWidth.slice(0, -2),
+                        bottom: +pageStyles.borderBottomWidth.slice(0, -2),
+                        right: +pageStyles.borderRightWidth.slice(0, -2),
+                    };
+                    pageRect = {
+                        ...pageRect,
+                        left: pageRect.left + border.left,
+                        top: pageRect.top + border.top,
+                        width: pageRect.width - border.left - border.right,
+                        height: pageRect.height - border.top - border.bottom,
+                    };
+                    rectElem.classList.add(classes.rect);
+                    start = getRelativePosition(position, pageRect);
+                    return true;
+                }
+            }
+            return false;
+        };
+        
+        const cleanup = (endPosition: IPoint) => {
+            if (!pageElement || !rectElem || !start || !pageRect) return;
+
+            const rect = calculateRectDimensions(start, endPosition, pageRect);
+            pageElement.removeChild(rectElem);
+            if (rect.width > threshold.x || rect.height > threshold.y) {
+                callbackRef.current({
+                    rect,
+                    pageNum: parseInt(pageElement.getAttribute("data-page-number")!),
+                });
+            }
+            start = pageRect = pageElement = rectElem = undefined;
+        };
+
+        const handleMouseDown = (e: MouseEvent) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (init(e.target, { x: e.clientX, y: e.clientY })) {
+                window.addEventListener("mousemove", handleMouseMove);
+            }
+        };
+
+        const handleMouseMove = (e: MouseEvent) => {
+            if (!start || !pageRect || !rectElem) return;
+            e.preventDefault();
+            const rect = calculateRectDimensions(start, { x: e.clientX, y: e.clientY }, pageRect);
+            updateDOMRect(rectElem, rect);
+        };
+
+        const handleMouseUp = (e: MouseEvent) => {
+            window.removeEventListener("mousemove", handleMouseMove);
+            cleanup({ x: e.clientX, y: e.clientY });
+        };
+
+        const handleTouchStart = (e: TouchEvent) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (e.touches.length === 1) {
+                const master = e.touches[0];
+                if (init(e.target, { x: master.clientX, y: master.clientY })) {
+                    window.addEventListener("touchmove", handleTouchMove);
+                }
+            }
+        };
+
+        let lastPosition: IPoint;
+
+        const handleTouchMove = (e: TouchEvent) => {
+            if (!start || !pageRect || !rectElem) return;
+            e.preventDefault();
+            const touch = e.touches[e.touches.length - 1];
+            lastPosition = { x: touch.clientX, y: touch.clientY };
+            const rect = calculateRectDimensions(start, lastPosition, pageRect);
+            updateDOMRect(rectElem, rect);
+        };
+
+        const handleTouchEnd = () => {
+            window.removeEventListener("touchmove", handleTouchMove);
+            cleanup(lastPosition);
+        };
+
+        const targets = ControlledAnnotationBars
+            .computeTargets("pdf", docViewerElements.getDocViewerElement);
+
+        window.addEventListener("mouseup", handleMouseUp);
+        window.addEventListener("touchend", handleTouchEnd);
+        for (let target of targets) {
+            target.addEventListener("mousedown", handleMouseDown);
+            target.addEventListener("touchstart", handleTouchStart);
+        }
+
+        return () => {
+            for (let target of targets) {
+                target.removeEventListener("mousedown", handleMouseDown);
+                target.removeEventListener("touchstart", handleTouchStart);
+            }
+            window.removeEventListener("mouseup", handleMouseUp);
+            window.removeEventListener("touchend", handleTouchStart);
+        };
+    }, [enabled, classes]);
+};

--- a/apps/doc/src/annotations/AreaHighlightHooks.ts
+++ b/apps/doc/src/annotations/AreaHighlightHooks.ts
@@ -17,7 +17,7 @@ import {useDocViewerContext} from "../renderers/DocRenderer";
 import {useDocViewerElementsContext} from "../renderers/DocViewerElementsContext";
 
 export interface AreaHighlightCreatedOpts {
-    readonly pointWithinPageElement: IPoint;
+    readonly rectWithinPageElement: ILTRect;
     readonly pageNum: number;
 }
 
@@ -45,7 +45,7 @@ export function useAreaHighlightHooks(): IAreaHighlightHooks {
 
     const onAreaHighlightCreatedAsync = React.useCallback(async (opts: AreaHighlightCreatedOpts) => {
 
-        const {pageNum, pointWithinPageElement} = opts;
+        const {pageNum, rectWithinPageElement} = opts;
 
         if (docScale && docMeta) {
 
@@ -53,7 +53,7 @@ export function useAreaHighlightHooks(): IAreaHighlightHooks {
 
             const capturedAreaHighlight =
                 await createAreaHighlightFromEvent(pageNum,
-                                                   pointWithinPageElement,
+                                                   rectWithinPageElement,
                                                    docScale,
                                                    fileType,
                                                    docViewerElement);

--- a/apps/doc/src/annotations/AreaHighlightRenderer.tsx
+++ b/apps/doc/src/annotations/AreaHighlightRenderer.tsx
@@ -37,21 +37,18 @@ export const AreaHighlightRenderer = deepMemo(function AreaHighlightRenderer(pro
     const [draggable, setDraggable] = React.useState(false);
 
     React.useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.ctrlKey || e.metaKey) {
+        const handleKey = (e: KeyboardEvent) => {
+            if (e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
                 setDraggable(true);
-            }
-        };
-        const handleKeyUp = (e: KeyboardEvent) => {
-            if (!e.ctrlKey && !e.metaKey) {
+            } else {
                 setDraggable(false);
             }
         };
-        window.addEventListener('keydown', handleKeyDown, {passive: true});
-        window.addEventListener('keyup', handleKeyUp, {passive: true});
+        window.addEventListener('keydown', handleKey, {passive: true});
+        window.addEventListener('keyup', handleKey, {passive: true});
         return () => {
-            window.removeEventListener('keydown', handleKeyDown);
-            window.removeEventListener('keyup', handleKeyUp);
+            window.removeEventListener('keydown', handleKey);
+            window.removeEventListener('keyup', handleKey);
         };
     }, [setDraggable]);
 

--- a/apps/doc/src/annotations/AreaHighlightRenderer.tsx
+++ b/apps/doc/src/annotations/AreaHighlightRenderer.tsx
@@ -90,6 +90,27 @@ export const AreaHighlightRenderer = deepMemo(function AreaHighlightRenderer(pro
 
         const areaHighlightRect = AreaHighlightRects.createFromRect(rect);
         const overlayRect = toOverlayRect(areaHighlightRect);
+        const [draggable, setDraggable] = React.useState(false);
+
+        // TODO: REVIEW. This is the part I don't like very much
+        React.useEffect(() => {
+            const handleKeyDown = (e: KeyboardEvent) => {
+                if (e.ctrlKey || e.metaKey) {
+                    setDraggable(true);
+                }
+            };
+            const handleKeyUp = (e: KeyboardEvent) => {
+                if (!e.ctrlKey && !e.metaKey) {
+                    setDraggable(false);
+                }
+            };
+            window.addEventListener('keydown', handleKeyDown, {passive: true});
+            window.addEventListener('keyup', handleKeyUp, {passive: true});
+            return () => {
+                window.removeEventListener('keydown', handleKeyDown);
+                window.removeEventListener('keyup', handleKeyUp);
+            };
+        }, []);
 
         if (! overlayRect) {
             return null;
@@ -106,6 +127,7 @@ export const AreaHighlightRenderer = deepMemo(function AreaHighlightRenderer(pro
             <ResizeBox
                  id={id}
                  data-type="area-highlight"
+                 draggable={draggable}
                  data-doc-fingerprint={fingerprint}
                  data-area-highlight-id={areaHighlight.id}
                  data-annotation-id={areaHighlight.id}

--- a/apps/doc/src/annotations/AreaHighlightRenderer.tsx
+++ b/apps/doc/src/annotations/AreaHighlightRenderer.tsx
@@ -34,6 +34,27 @@ export const AreaHighlightRenderer = deepMemo(function AreaHighlightRenderer(pro
 
     const pageElement = docViewerElementsContext.getPageElementForPage(pageNum);
 
+    const [draggable, setDraggable] = React.useState(false);
+
+    React.useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.ctrlKey || e.metaKey) {
+                setDraggable(true);
+            }
+        };
+        const handleKeyUp = (e: KeyboardEvent) => {
+            if (!e.ctrlKey && !e.metaKey) {
+                setDraggable(false);
+            }
+        };
+        window.addEventListener('keydown', handleKeyDown, {passive: true});
+        window.addEventListener('keyup', handleKeyUp, {passive: true});
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+            window.removeEventListener('keyup', handleKeyUp);
+        };
+    }, [setDraggable]);
+
     const toOverlayRect = React.useCallback((areaHighlightRect: AreaHighlightRect): ILTRect | undefined => {
 
         if (! pageElement) {
@@ -90,27 +111,6 @@ export const AreaHighlightRenderer = deepMemo(function AreaHighlightRenderer(pro
 
         const areaHighlightRect = AreaHighlightRects.createFromRect(rect);
         const overlayRect = toOverlayRect(areaHighlightRect);
-        const [draggable, setDraggable] = React.useState(false);
-
-        // TODO: REVIEW. This is the part I don't like very much
-        React.useEffect(() => {
-            const handleKeyDown = (e: KeyboardEvent) => {
-                if (e.ctrlKey || e.metaKey) {
-                    setDraggable(true);
-                }
-            };
-            const handleKeyUp = (e: KeyboardEvent) => {
-                if (!e.ctrlKey && !e.metaKey) {
-                    setDraggable(false);
-                }
-            };
-            window.addEventListener('keydown', handleKeyDown, {passive: true});
-            window.addEventListener('keyup', handleKeyUp, {passive: true});
-            return () => {
-                window.removeEventListener('keydown', handleKeyDown);
-                window.removeEventListener('keyup', handleKeyUp);
-            };
-        }, []);
 
         if (! overlayRect) {
             return null;
@@ -152,7 +152,7 @@ export const AreaHighlightRenderer = deepMemo(function AreaHighlightRenderer(pro
             container,
             id);
 
-    }, [areaHighlight, createID, fingerprint, handleRegionResize, pageNum, toOverlayRect]);
+    }, [areaHighlight, createID, fingerprint, handleRegionResize, pageNum, toOverlayRect, draggable]);
 
     // const rect = Arrays.first(Object.values(areaHighlight.rects));
     //

--- a/apps/doc/src/annotations/AreaHighlightRenderers.ts
+++ b/apps/doc/src/annotations/AreaHighlightRenderers.ts
@@ -9,6 +9,7 @@ import {ICapturedScreenshot} from "../../../../web/js/screenshots/Screenshot";
 import {Position} from "polar-shared/src/metadata/IBaseHighlight";
 import {FileType} from "../../../../web/js/apps/main/file_loaders/FileType";
 import {Preconditions} from "polar-shared/src/Preconditions";
+import {IRect} from "polar-shared/src/util/rects/IRect";
 
 export namespace AreaHighlightRenderers {
 
@@ -21,14 +22,14 @@ export namespace AreaHighlightRenderers {
     }
 
     export async function createAreaHighlightFromEvent(pageNum: number,
-                                                       pointWithinPageElement: IPoint,
+                                                       areaHighlightRect: ILTRect,
                                                        docScale: IDocScale,
                                                        fileType: FileType,
                                                        docViewerElement: HTMLElement): Promise<ICapturedAreaHighlight> {
 
         Preconditions.assertPresent(fileType, 'fileType');
 
-        const rect = AnnotationRects.createFromPointWithinPageElement(pageNum, pointWithinPageElement, docViewerElement);
+        const rect = AnnotationRects.createFromPointWithinPageElement(pageNum, areaHighlightRect, docViewerElement);
 
         const pageDimensions = getPageElementDimensions(pageNum, docViewerElement);
 

--- a/apps/doc/src/annotations/ResizeBox.tsx
+++ b/apps/doc/src/annotations/ResizeBox.tsx
@@ -81,6 +81,20 @@ function deriveStateFromInitialPosition(computeInitialPosition: () => ILTRect): 
 
 }
 
+function toggleUserSelect(doc: Document, resizing: boolean) {
+    // this is a hack to disable user select of the document to prevent
+    // parts of the UI from being selected
+
+    if (resizing) {
+        doc.body.style.userSelect = 'none';
+        doc.body.style.webkitUserSelect = 'none';
+    } else {
+        doc.body.style.userSelect = 'auto';
+        doc.body.style.webkitUserSelect = 'auto';
+    }
+
+}
+
 export const ResizeBox = deepMemo(function ResizeBox(props: IProps) {
 
     const computeNewState = () => deriveStateFromInitialPosition(props.computePosition);
@@ -194,6 +208,7 @@ export const ResizeBox = deepMemo(function ResizeBox(props: IProps) {
     }
 
     const position = computePosition(state);
+    const doc = props.document || document;
 
     return (
         <>
@@ -211,12 +226,15 @@ export const ResizeBox = deepMemo(function ResizeBox(props: IProps) {
                     height: state.height
                 }}
                 position={position}
+                onDragStart={() => toggleUserSelect(doc, true)}
+                onResizeStart={() => toggleUserSelect(doc, true)}
                 onDragStop={(_, d) => {
                     handleResize({
                         ...state,
                         x: d.x,
                         y: d.y
                     }, "right");
+                    toggleUserSelect(doc, false)
                 }}
                 disableDragging={!props.draggable}
                 onResizeStop={(_,
@@ -231,7 +249,7 @@ export const ResizeBox = deepMemo(function ResizeBox(props: IProps) {
                         width: parseInt(ref.style.width),
                         height: parseInt(ref.style.height),
                     }, direction);
-
+                    toggleUserSelect(doc, false)
                 }}
                 enableResizing={props.enableResizing}
                 resizeHandleStyles={{

--- a/apps/doc/src/annotations/ResizeBox.tsx
+++ b/apps/doc/src/annotations/ResizeBox.tsx
@@ -25,6 +25,7 @@ interface IProps {
 
     readonly document?: Document;
     readonly window?: Window;
+    readonly draggable?: boolean;
 
     /**
      * Used to compute the initial position of the resize box during initial
@@ -80,42 +81,6 @@ function deriveStateFromInitialPosition(computeInitialPosition: () => ILTRect): 
 
 }
 
-function computeNewBox(box: IBox, direction: ResizeDirection, delta: ResizableDelta): IBox {
-
-    if (direction.startsWith('left') || direction.startsWith('top')) {
-        return {
-            x: box.x - delta.width,
-            width: box.width + delta.width,
-            y: box.y - delta.height,
-            height: box.height + delta.height
-        };
-    }
-
-    if (direction.startsWith('right') || direction.startsWith('bottom')) {
-        return {
-            x: box.x,
-            y: box.y,
-            width: box.width + delta.width,
-            height: box.height + delta.height
-        };
-    }
-
-    throw new Error("unhandled direction: " + direction);
-
-}
-
-function toggleUserSelect(doc: Document, resizing: boolean) {
-    // this is a hack to disable user select of the document to prevent
-    // parts of the UI from being selected
-
-    if (resizing) {
-        doc.body.style.userSelect = 'none';
-    } else {
-        doc.body.style.userSelect = 'auto';
-    }
-
-}
-
 export const ResizeBox = deepMemo(function ResizeBox(props: IProps) {
 
     const computeNewState = () => deriveStateFromInitialPosition(props.computePosition);
@@ -136,6 +101,8 @@ export const ResizeBox = deepMemo(function ResizeBox(props: IProps) {
         scrollIntoViewRef(rndRef.current ? rndRef.current.getSelfElement() : null);
 
     }, [scrollIntoViewRef]);
+
+
 
     const handleResize = React.useCallback((newState: IState,
                                             direction: ResizeDirection) => {
@@ -227,7 +194,6 @@ export const ResizeBox = deepMemo(function ResizeBox(props: IProps) {
     }
 
     const position = computePosition(state);
-    const doc = props.document || document;
 
     return (
         <>
@@ -244,32 +210,29 @@ export const ResizeBox = deepMemo(function ResizeBox(props: IProps) {
                     width: state.width,
                     height: state.height
                 }}
-                onMouseDown={() => toggleUserSelect(doc, true)}
-                onMouseUp={() => toggleUserSelect(doc, false)}
                 position={position}
-                // onMouseOver={() => handleOnMouseOver()}
-                // onMouseOut={() => handleOnMouseOut()}
-                onDragStop={(e, d) => {
-                    // handleResize({
-                    //     ...state,
-                    //     x: d.x,
-                    //     y: d.y
-                    // });
+                onDragStop={(_, d) => {
+                    handleResize({
+                        ...state,
+                        x: d.x,
+                        y: d.y
+                    }, "right");
                 }}
-                onResizeStop={(event,
+                disableDragging={!props.draggable}
+                onResizeStop={(_,
                                direction,
-                               elementRef,
-                               delta) => {
-
-                    const box = computeNewBox(state, direction, delta);
+                               ref,
+                               _1,
+                               position) => {
 
                     handleResize({
                         ...state,
-                        ...box,
+                        ...position,
+                        width: parseInt(ref.style.width),
+                        height: parseInt(ref.style.height),
                     }, direction);
 
                 }}
-                disableDragging={true}
                 enableResizing={props.enableResizing}
                 resizeHandleStyles={{
                     top: {
@@ -327,7 +290,8 @@ export const ResizeBox = deepMemo(function ResizeBox(props: IProps) {
                 }}
                 style={{
                     ...props.style,
-                    pointerEvents: 'none',
+                    pointerEvents: props.draggable ? 'auto' : 'none',
+                    cursor: props.draggable ? 'move' : 'auto',
                 }}
                 {...dataProps}>
                 {/*<div onContextMenu={props.onContextMenu}*/}

--- a/apps/doc/src/renderers/pdf/PDFDocument.tsx
+++ b/apps/doc/src/renderers/pdf/PDFDocument.tsx
@@ -22,7 +22,8 @@ import {
 import {
     IDocDescriptor,
     IDocScale,
-    useDocViewerCallbacks
+    useDocViewerCallbacks,
+    useDocViewerStore
 } from "../../DocViewerStore";
 import {useDocFindCallbacks} from "../../DocFindStore";
 import {PageNavigator} from "../../PageNavigator";
@@ -41,7 +42,6 @@ import {useLogger} from "../../../../../web/js/mui/MUILogger";
 import {KnownPrefs} from "../../../../../web/js/util/prefs/KnownPrefs";
 import {useAnnotationBar} from "../../AnnotationBarHooks";
 import {DocumentInit} from "../DocumentInitHook";
-import {useDocViewerPageJumpListener} from '../../DocViewerAnnotationHook';
 import {deepMemo} from "../../../../../web/js/react/ReactUtils";
 import {IOutlineItem} from "../../outline/IOutlineItem";
 import Outline = _pdfjs.Outline;
@@ -54,6 +54,7 @@ import {usePrefsContext} from "../../../../repository/js/persistence_layer/Prefs
 import { usePDFUpgrader } from './PDFUpgrader';
 import {ViewerElements} from "../ViewerElements";
 import {useDocumentViewerVisibleElemFocus} from '../UseSidenavDocumentChangeCallbackHook';
+import {AreaHighlightCreator} from '../../annotations/AreaHighlightDrawer';
 
 interface DocViewer {
     readonly eventBus: EventBus;
@@ -456,6 +457,7 @@ export const PDFDocument = deepMemo(function PDFDocument(props: IProps) {
 
     return active && (
         <>
+            <AreaHighlightCreator />
             <DocumentInit/>
             {props.children}
         </>

--- a/apps/doc/src/toolbar/DocViewerToolbar.tsx
+++ b/apps/doc/src/toolbar/DocViewerToolbar.tsx
@@ -14,7 +14,6 @@ import {useDocViewerCallbacks, useDocViewerStore} from "../DocViewerStore";
 import Divider from "@material-ui/core/Divider";
 import {DeviceRouters} from "../../../../web/js/ui/DeviceRouter";
 import {useDocFindStore} from "../DocFindStore";
-import {DocumentWriteStatus} from "../../../../web/js/apps/repository/connectivity/DocumentWriteStatus";
 import {MUIDocFlagButton} from "../../../repository/js/doc_repo/buttons/MUIDocFlagButton";
 import {MUIDocArchiveButton} from "../../../repository/js/doc_repo/buttons/MUIDocArchiveButton";
 import {DocViewerToolbarOverflowButton} from "../DocViewerToolbarOverflowButton";
@@ -28,6 +27,9 @@ import {deepMemo} from "../../../../web/js/react/ReactUtils";
 import {DockLayoutToggleButton} from "../../../../web/js/ui/doc_layout/DockLayoutToggleButton";
 import {ZenModeActiveContainer} from "../../../../web/js/mui/ZenModeActiveContainer";
 import {ZenModeButton} from "./ZenModeButton";
+import ImageIcon from "@material-ui/icons/Image";
+import {StandardToggleButton} from "../../../repository/js/doc_repo/buttons/StandardToggleButton";
+import {MUIDocAreaHighlightModeToggle} from "../../../repository/js/doc_repo/buttons/MUIDocAreaHighlightModeToggle";
 
 const getScaleLevelTuple = (scale: ScaleLevel) => (
     arrayStream(ScaleLevelTuples)
@@ -37,10 +39,10 @@ const getScaleLevelTuple = (scale: ScaleLevel) => (
 
 export const DocViewerToolbar = deepMemo(function DocViewerToolbar() {
 
-    const {docScale, pageNavigator, scaleLeveler, docMeta}
-        = useDocViewerStore(['docScale', 'pageNavigator', 'scaleLeveler', 'docMeta']);
+    const {docScale, pageNavigator, scaleLeveler, docMeta, areaHighlightModeActive}
+        = useDocViewerStore(['docScale', 'pageNavigator', 'scaleLeveler', 'docMeta', 'areaHighlightModeActive']);
     const {finder} = useDocFindStore(['finder']);
-    const {setScale, onDocTagged, doZoom, toggleDocArchived, toggleDocFlagged} = useDocViewerCallbacks();
+    const {setScale, onDocTagged, doZoom, toggleDocArchived, toggleDocFlagged, setAreaHighlightModeActive} = useDocViewerCallbacks();
 
     const handleScaleChange = React.useCallback((scale: ScaleLevel) => {
 
@@ -163,6 +165,13 @@ export const DocViewerToolbar = deepMemo(function DocViewerToolbar() {
 
 
                                 {/* TODO: implement keyboard shortcuts for these. */}
+                                <MUIDocAreaHighlightModeToggle
+                                    onClick={() => setAreaHighlightModeActive(!areaHighlightModeActive)}
+                                    active={areaHighlightModeActive}
+                                />
+
+                                <Divider orientation="vertical" flexItem/>
+
                                 <MUIDocTagButton size="small"
                                                  onClick={onDocTagged}/>
 
@@ -174,7 +183,7 @@ export const DocViewerToolbar = deepMemo(function DocViewerToolbar() {
                                                   onClick={toggleDocFlagged}
                                                   active={docMeta?.docInfo?.flagged}/>
 
-                                <Divider orientation="vertical" flexItem={true}/>
+                                <Divider orientation="vertical" flexItem/>
 
                                 {/*
                                 <div className="ml-3 mr-2" style={{display: 'flex'}}>

--- a/apps/doc/src/toolbar/DocViewerToolbar.tsx
+++ b/apps/doc/src/toolbar/DocViewerToolbar.tsx
@@ -27,8 +27,6 @@ import {deepMemo} from "../../../../web/js/react/ReactUtils";
 import {DockLayoutToggleButton} from "../../../../web/js/ui/doc_layout/DockLayoutToggleButton";
 import {ZenModeActiveContainer} from "../../../../web/js/mui/ZenModeActiveContainer";
 import {ZenModeButton} from "./ZenModeButton";
-import ImageIcon from "@material-ui/icons/Image";
-import {StandardToggleButton} from "../../../repository/js/doc_repo/buttons/StandardToggleButton";
 import {MUIDocAreaHighlightModeToggle} from "../../../repository/js/doc_repo/buttons/MUIDocAreaHighlightModeToggle";
 
 const getScaleLevelTuple = (scale: ScaleLevel) => (
@@ -39,10 +37,10 @@ const getScaleLevelTuple = (scale: ScaleLevel) => (
 
 export const DocViewerToolbar = deepMemo(function DocViewerToolbar() {
 
-    const {docScale, pageNavigator, scaleLeveler, docMeta, areaHighlightModeActive}
-        = useDocViewerStore(['docScale', 'pageNavigator', 'scaleLeveler', 'docMeta', 'areaHighlightModeActive']);
+    const {docScale, pageNavigator, scaleLeveler, docMeta, areaHighlightMode}
+        = useDocViewerStore(['docScale', 'pageNavigator', 'scaleLeveler', 'docMeta', 'areaHighlightMode']);
     const {finder} = useDocFindStore(['finder']);
-    const {setScale, onDocTagged, doZoom, toggleDocArchived, toggleDocFlagged, setAreaHighlightModeActive} = useDocViewerCallbacks();
+    const {setScale, onDocTagged, doZoom, toggleDocArchived, toggleDocFlagged, toggleAreaHighlightMode} = useDocViewerCallbacks();
 
     const handleScaleChange = React.useCallback((scale: ScaleLevel) => {
 
@@ -164,10 +162,9 @@ export const DocViewerToolbar = deepMemo(function DocViewerToolbar() {
                             <MUIButtonBar>
 
 
-                                {/* TODO: implement keyboard shortcuts for these. */}
                                 <MUIDocAreaHighlightModeToggle
-                                    onClick={() => setAreaHighlightModeActive(!areaHighlightModeActive)}
-                                    active={areaHighlightModeActive}
+                                    onClick={toggleAreaHighlightMode}
+                                    active={areaHighlightMode}
                                 />
 
                                 <Divider orientation="vertical" flexItem/>

--- a/apps/repository/js/doc_repo/buttons/MUIDocAreaHighlightModeToggle.tsx
+++ b/apps/repository/js/doc_repo/buttons/MUIDocAreaHighlightModeToggle.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import Crop54Icon from '@material-ui/icons/Crop54';
+import PhotoSizeSelectLargeIcon from '@material-ui/icons/PhotoSizeSelectLarge';
 import { ToggleButtonProps, StandardToggleButton } from "./StandardToggleButton";
 
 export const MUIDocAreaHighlightModeToggle = React.memo((props: ToggleButtonProps) => (
     <StandardToggleButton tooltip="Area highlight mode" {...props}>
-        <Crop54Icon/>
+        <PhotoSizeSelectLargeIcon/>
     </StandardToggleButton>
 ));

--- a/apps/repository/js/doc_repo/buttons/MUIDocAreaHighlightModeToggle.tsx
+++ b/apps/repository/js/doc_repo/buttons/MUIDocAreaHighlightModeToggle.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import Crop54Icon from '@material-ui/icons/Crop54';
+import { ToggleButtonProps, StandardToggleButton } from "./StandardToggleButton";
+
+export const MUIDocAreaHighlightModeToggle = React.memo((props: ToggleButtonProps) => (
+    <StandardToggleButton tooltip="Area highlight mode" {...props}>
+        <Crop54Icon/>
+    </StandardToggleButton>
+));

--- a/web/js/apps/main/doc_loaders/sidenav/SideNavDocLoaders.ts
+++ b/web/js/apps/main/doc_loaders/sidenav/SideNavDocLoaders.ts
@@ -36,7 +36,7 @@ export function useSideNavDocLoader() {
             const viewerURL = ViewerURLs.create(persistenceLayerProvider, loadDocRequest);
 
             const url = viewerURL.replace("http://localhost:8050", "")
-                                 .replace("https://app.getpolarized.io", "");
+                                 .replace("https://localapp.getpolarized.io", "");
 
             addTab({
                 id: loadDocRequest.fingerprint,

--- a/web/js/apps/main/doc_loaders/sidenav/SideNavDocLoaders.ts
+++ b/web/js/apps/main/doc_loaders/sidenav/SideNavDocLoaders.ts
@@ -36,7 +36,7 @@ export function useSideNavDocLoader() {
             const viewerURL = ViewerURLs.create(persistenceLayerProvider, loadDocRequest);
 
             const url = viewerURL.replace("http://localhost:8050", "")
-                                 .replace("https://localapp.getpolarized.io", "");
+                                 .replace("https://app.getpolarized.io", "");
 
             addTab({
                 id: loadDocRequest.fingerprint,

--- a/web/js/metadata/AnnotationRects.ts
+++ b/web/js/metadata/AnnotationRects.ts
@@ -6,6 +6,7 @@ import {Rects} from '../Rects';
 import {IDimensions} from "../util/IDimensions";
 import {IPoint} from "../Point";
 import {ILTRect} from "polar-shared/src/util/rects/ILTRect";
+import {IRect} from 'polar-shared/src/util/rects/IRect';
 
 export namespace AnnotationRects {
 
@@ -47,13 +48,13 @@ export namespace AnnotationRects {
 
     }
 
-    export function createFromPointWithinPageElement(pageNum: number, pointWithinPageElement: IPoint, docViewerElem: HTMLElement) {
+    export function createFromPointWithinPageElement(pageNum: number, rect: ILTRect, docViewerElem: HTMLElement) {
 
         const pageElement = getPageElement(pageNum, docViewerElem);
 
         if (pageElement) {
             const containerDimensions = computeContainerDimensions(pageElement);
-            return createFromPointWithinPageAndContainer(pointWithinPageElement, containerDimensions)
+            return createFromRectWithinPageAndContainer(rect, containerDimensions)
         }
 
         throw new Error("No page found at point");
@@ -76,14 +77,9 @@ export namespace AnnotationRects {
     /**
      * Create from clientX and clientY point
      */
-    export function createFromPointWithinPageAndContainer(pointWithinPageElement: IPoint, containerDimensions: IDimensions) {
+    export function createFromRectWithinPageAndContainer(rect: ILTRect, containerDimensions: IDimensions) {
 
-        const boxRect = Rects.createFromBasicRect({
-            left: pointWithinPageElement.x,
-            top: pointWithinPageElement.y,
-            width: 150,
-            height: 150
-        });
+        const boxRect = Rects.createFromBasicRect(rect);
 
         return createFromOverlayRectWithinPageAndContainer(boxRect, containerDimensions);
 

--- a/web/js/ui/annotationbar/ControlledAnnotationBars.tsx
+++ b/web/js/ui/annotationbar/ControlledAnnotationBars.tsx
@@ -135,7 +135,7 @@ export namespace ControlledAnnotationBars {
 
     }
 
-    function computeTargets(fileType: FileType, docViewerElementProvider: () => HTMLElement): ReadonlyArray<HTMLElement> {
+    export function computeTargets(fileType: FileType, docViewerElementProvider: () => HTMLElement): ReadonlyArray<HTMLElement> {
 
         const docViewerElement = docViewerElementProvider();
 


### PR DESCRIPTION
### Changelog:
- Add area highlight rectangle drawer.
- Add toggle button in the doc viewer toolbar to enable the area highlight mode (with a shortcut "a").
- Add the ability to reposition area highlights when holding down the "Shift" key.
- Fix issues with resizing area highlights (used to be broken when resized from the corners or the top and left sides)