### PR TITLE
New annotation popup bar bug fixes & improvements.

### DIFF
--- a/apps/doc/src/annotations/annotation_popup/AnnotationPopup.tsx
+++ b/apps/doc/src/annotations/annotation_popup/AnnotationPopup.tsx
@@ -93,9 +93,7 @@ const AnnotationPopupEPUBRenderer: React.FC<IAnnotationPopupEPUBRendererProps> =
     const boundsElement = React.useMemo(() => (
         docViewerElementsRef.current.getDocViewerElement().querySelector<HTMLIFrameElement>("iframe")
     ), [docViewerElementsRef]);
-    const scrollElement = React.useMemo(() => (
-        boundsElement?.contentWindow || null
-    ), [docViewerElementsRef, boundsElement]);
+    const scrollElement = React.useMemo(() => boundsElement?.contentWindow || null, [boundsElement]);
 
     const ref = useAnnotationPopupPositionUpdater({
         rect,

--- a/apps/doc/src/annotations/annotation_popup/AnnotationPopup.tsx
+++ b/apps/doc/src/annotations/annotation_popup/AnnotationPopup.tsx
@@ -91,15 +91,11 @@ type IAnnotationPopupEPUBRendererProps = {
 const AnnotationPopupEPUBRenderer: React.FC<IAnnotationPopupEPUBRendererProps> = ({ rect }) => {
     const docViewerElementsRef = useRefWithUpdates(useDocViewerElementsContext());
     const boundsElement = React.useMemo(() => (
-        docViewerElementsRef.current.getDocViewerElement()
+        docViewerElementsRef.current.getDocViewerElement().querySelector<HTMLIFrameElement>("iframe")
     ), [docViewerElementsRef]);
     const scrollElement = React.useMemo(() => (
-        docViewerElementsRef
-            .current
-            .getDocViewerElement()
-            .querySelector<HTMLIFrameElement>("iframe")
-            ?.contentWindow || null
-    ), [docViewerElementsRef]);
+        boundsElement?.contentWindow || null
+    ), [docViewerElementsRef, boundsElement]);
 
     const ref = useAnnotationPopupPositionUpdater({
         rect,

--- a/apps/doc/src/annotations/annotation_popup/AnnotationPopupActions.tsx
+++ b/apps/doc/src/annotations/annotation_popup/AnnotationPopupActions.tsx
@@ -14,6 +14,7 @@ import {CopyAnnotation} from "./Actions/CopyAnnotation";
 import {CreateAIFlashcard} from "./Actions/CreateAIFlashcard";
 import {EditTags} from "./Actions/EditTags";
 import {DeleteAnnotation} from "./Actions/DeleteAnnotation";
+import {ANNOTATION_COLOR_SHORTCUT_KEYS} from "./AnnotationPopupShortcuts";
 
 
 export type IAnnotationPopupActionProps = {
@@ -35,7 +36,12 @@ const ColorPicker: React.FC<IAnnotationPopupActionProps> = (props) => {
 
     return (
         <div className={className} style={{ ...style, width: "auto" }}>
-            <ColorMenu selected={annotation.color} onChange={handleChange} />
+            <ColorMenu
+                selected={annotation.color}
+                onChange={handleChange}
+                hintLimit={ANNOTATION_COLOR_SHORTCUT_KEYS.length}
+                withHints
+            />
         </div>
     );
 };

--- a/apps/doc/src/annotations/annotation_popup/AnnotationPopupActions.tsx
+++ b/apps/doc/src/annotations/annotation_popup/AnnotationPopupActions.tsx
@@ -53,6 +53,7 @@ const useStyles = makeStyles((theme) =>
             transformOrigin: "bottom center",
             boxShadow: theme.shadows[8],
             width: "100%",
+            zIndex: 2,
         },
     }),
 );

--- a/apps/doc/src/annotations/annotation_popup/AnnotationPopupBar.tsx
+++ b/apps/doc/src/annotations/annotation_popup/AnnotationPopupBar.tsx
@@ -11,9 +11,7 @@ import CommentIcon from "@material-ui/icons/Comment";
 import PaletteIcon from "@material-ui/icons/Palette";
 import {StandardIconButton} from "../../../../repository/js/doc_repo/buttons/StandardIconButton";
 import {MUIButtonBar} from "../../../../../web/js/mui/MUIButtonBar";
-import {MUIDocDeleteButton} from "../../../../repository/js/doc_repo/buttons/MUIDocDeleteButton";
 import {NULL_FUNCTION} from "polar-shared/src/util/Functions";
-import {useAnnotationMutationsContext} from "../../../../../web/js/annotation_sidebar/AnnotationMutationsContext";
 import {MUIDropdownCaret} from "../../../../../web/js/mui/MUIDropdownCaret";
 import {useAnnotationPopupStyles} from "./AnnotationPopup";
 import {AnnotationPopupActionEnum, useAnnotationPopup} from "./AnnotationPopupContext";
@@ -39,20 +37,20 @@ export const AnnotationPopupBar: React.FC = () => {
                     onToggle={toggleAction(AnnotationPopupActionEnum.CHANGE_COLOR)}
                 />
                 <Divider orientation="vertical" flexItem />
-                <ActionButton tooltip="Edit highlight" action={AnnotationPopupActionEnum.EDIT}>
+                <ActionButton tooltip="Edit highlight (e)" action={AnnotationPopupActionEnum.EDIT}>
                     <EditIcon />
                 </ActionButton>
-                <ActionButton tooltip="Comment" action={AnnotationPopupActionEnum.CREATE_COMMENT}>
+                <ActionButton tooltip="Comment (c)" action={AnnotationPopupActionEnum.CREATE_COMMENT}>
                     <CommentIcon />
                 </ActionButton>
                 <ActionButton
-                    tooltip="Create flashcard manually"
+                    tooltip="Create flashcard manually (f)"
                     action={AnnotationPopupActionEnum.CREATE_FLASHCARD}
                 >
                     <FlashOnIcon />
                 </ActionButton>
                 <ActionButton
-                    tooltip="Create flashcard automatically"
+                    tooltip="Create flashcard automatically (g)"
                     action={AnnotationPopupActionEnum.CREATE_AI_FLASHCARD}
                 >
                     {aiFlashcardStatus === "waiting"
@@ -60,7 +58,7 @@ export const AnnotationPopupBar: React.FC = () => {
                         : <FlashAutoIcon/>
                     }
                 </ActionButton>
-                <ActionButton tooltip="Tag highlight" action={AnnotationPopupActionEnum.EDIT_TAGS}>
+                <ActionButton tooltip="Tag highlight (t)" action={AnnotationPopupActionEnum.EDIT_TAGS}>
                     <LocalOfferIcon />
                 </ActionButton>
                 <Divider orientation="vertical" flexItem />
@@ -68,7 +66,7 @@ export const AnnotationPopupBar: React.FC = () => {
                     <NoteIcon />
                 </ActionButton>
                 {annotation && (
-                    <ActionButton tooltip="Delete" action={AnnotationPopupActionEnum.DELETE}>
+                    <ActionButton tooltip="Delete (d)" action={AnnotationPopupActionEnum.DELETE}>
                         <DeleteIcon/>
                     </ActionButton>
                 )}

--- a/apps/doc/src/annotations/annotation_popup/AnnotationPopupContext.tsx
+++ b/apps/doc/src/annotations/annotation_popup/AnnotationPopupContext.tsx
@@ -238,13 +238,16 @@ export const AnnotationPopupProvider: React.FC<IAnnotationPopupProviderProps> = 
             if (!annotation) {
                 setActiveHighlight(undefined);
             }
-            dispatch({ type: ACTIONS.ANNOTATION_SET, payload: annotation });
+            setTimeout(() => {
+                dispatch({ type: ACTIONS.ANNOTATION_SET, payload: annotation });
+            }, 50);
         }
     }, [activeHighlight, setActiveHighlight, docMeta]);
     
     React.useEffect(() => {
         const targets = computeTargets(fileType, docViewerElementsRef.current.getDocViewerElement);
         const handleSelection: ActiveSelectionListener = (event) => {
+            dispatch({ type: ACTIONS.RESET, payload: undefined });
             if (textHighlightColorRef.current) {
                 if (event.type === "created") {
                     handleCreateAnnotation(textHighlightColorRef.current, event);

--- a/apps/doc/src/annotations/annotation_popup/AnnotationPopupHooks.tsx
+++ b/apps/doc/src/annotations/annotation_popup/AnnotationPopupHooks.tsx
@@ -15,6 +15,8 @@ import {ILTRect} from "polar-shared/src/util/rects/ILTRect";
 import {useDOMTextIndexContext} from "../DOMTextIndexContext";
 import {useRefWithUpdates} from "../../../../../web/js/hooks/ReactHooks";
 import {Texts} from "polar-shared/src/metadata/Texts";
+import {rangeConstrain} from "../AreaHighlightDrawer";
+import {useResizeObserver} from "../../renderers/pdf/PinchToZoomHooks";
 
 export type ActiveHighlightData = {
     highlightID: string;
@@ -140,14 +142,21 @@ namespace AnnotationPositionCalculator {
             if (!pageElem || !viewerElem || !docViewerElem || !rects.length) {
                 return;
             }
+            const pageStyles = window.getComputedStyle(pageElem);
+            const border = {
+                top: +pageStyles.borderTopWidth.slice(0, -2),
+                left: +pageStyles.borderLeftWidth.slice(0, -2),
+                bottom: +pageStyles.borderBottomWidth.slice(0, -2),
+                right: +pageStyles.borderRightWidth.slice(0, -2),
+            };
             const pageRect = pageElem.getBoundingClientRect();
             const viewerRect = viewerElem.getBoundingClientRect();
             const rect = rects.reduce(TextHighlightMerger.mergeRects);
             const scale = docScale.scaleValue;
 
             return {
-                left: rect.left * scale + pageRect.left - viewerRect.left, 
-                top: rect.top * scale + pageRect.top - viewerRect.top,
+                left: rect.left * scale + pageRect.left - viewerRect.left + border.left, 
+                top: rect.top * scale + pageRect.top - viewerRect.top + border.top,
                 width: rect.width * scale,
                 height: rect.height * scale,
             };
@@ -198,4 +207,71 @@ export const usePopupBarPosition = (opts: IUsePopupBarPositionOpts): ILTRect | u
         return;
         // TODO: Prevent rerenders if the annotation rects haven't changed
     }, [fileType, annotation, selectionEvent, docScale, textIndex, docViewerElementsRef]);
+};
+
+const CONTAINER_SPACING = 10;
+const constrainToContainer = (container: HTMLElement, scrollY: number, popup: HTMLElement, rect: ILTRect): { rect: ILTRect, isTop: boolean } => {
+    const containerRect = container.getBoundingClientRect();
+    const popupRect = popup.getBoundingClientRect();
+    const isTop = rect.top + (rect.height / 2) - scrollY >= containerRect.height / 2;
+
+    const obj = {
+        isTop,
+        rect: {
+            ...rect,
+            top: (isTop
+                ? Math.round(rect.top - popupRect.height) - CONTAINER_SPACING
+                : rect.top + rect.height) - scrollY + CONTAINER_SPACING,
+            left: rangeConstrain(
+                Math.round(rect.left + rect.width / 2 - popupRect.width / 2),
+                CONTAINER_SPACING,
+                containerRect.width - CONTAINER_SPACING - popupRect.width,
+            ),
+        },
+    };
+    return obj;
+};
+
+type IUseAnnotationPopupPositionUpdaterProps = {
+    boundsElement: HTMLElement | null;
+    scrollElement: HTMLElement | Window | null;
+    rect: ILTRect;
+    noScroll?: boolean;
+};
+
+const isWindow = (x: any): x is Window => {
+    return x.window === x;
+};
+
+export const useAnnotationPopupPositionUpdater = (
+    opts: IUseAnnotationPopupPositionUpdaterProps
+): React.RefObject<HTMLDivElement> => {
+    const {boundsElement, scrollElement, rect, noScroll = false} = opts;
+    const ref = React.useRef<HTMLDivElement>(null);
+    const updatePosition = React.useCallback(() => {
+        const popupElem = ref.current;
+        if (!popupElem || !boundsElement || !scrollElement) {
+            return;
+        }
+
+        const scrollY = isWindow(scrollElement) ? scrollElement.scrollY : scrollElement.scrollTop;
+        const {rect: {left, top}, isTop} = constrainToContainer(boundsElement, scrollY, popupElem, rect);
+        popupElem.style.transform = `translate3d(calc(${left}px), calc(${top + (noScroll ? scrollY : 0)}px), 0)`;
+        popupElem.classList[isTop ? "remove" : "add"]("flipped");
+    }, [rect, boundsElement, scrollElement, ref]);
+
+    React.useEffect(() => {
+        const popupElem = ref.current;
+        if (!popupElem || !boundsElement || !scrollElement) {
+            return;
+        }
+        updatePosition();
+        const onScroll = () => updatePosition();
+        scrollElement.addEventListener("scroll", onScroll, {passive: true});
+        return () => scrollElement.removeEventListener("scroll", onScroll);
+    }, [boundsElement, scrollElement, updatePosition, ref]);
+
+    useResizeObserver(updatePosition, {current: boundsElement || null});
+
+    return ref;
 };

--- a/apps/doc/src/annotations/annotation_popup/AnnotationPopupHooks.tsx
+++ b/apps/doc/src/annotations/annotation_popup/AnnotationPopupHooks.tsx
@@ -267,7 +267,7 @@ export const useAnnotationPopupPositionUpdater = (
         const {rect: {left, top}, isTop} = constrainToContainer(boundsElement, scrollElement, popupElem, rect);
         popupElem.style.transform = `translate3d(calc(${left}px), calc(${top + (noScroll ? scrollY : 0)}px), 0)`;
         popupElem.classList[isTop ? "remove" : "add"]("flipped");
-    }, [rect, boundsElement, scrollElement, ref]);
+    }, [rect, boundsElement, scrollElement, ref, noScroll]);
 
     React.useEffect(() => {
         const popupElem = ref.current;

--- a/apps/doc/src/toolbar/AreaHighlightModeToggle.tsx
+++ b/apps/doc/src/toolbar/AreaHighlightModeToggle.tsx
@@ -6,8 +6,6 @@ import {GlobalKeyboardShortcuts, keyMapWithGroup} from "../../../../web/js/keybo
 import {useDocViewerCallbacks, useDocViewerStore} from "../DocViewerStore";
 import {useDocViewerContext} from "../renderers/DocRenderer";
 import {StandardToggleButton} from "../../../repository/js/doc_repo/buttons/StandardToggleButton";
-import {Divider} from "@material-ui/core";
-
 
 const globalKeyMap = keyMapWithGroup({
     group: "Document Viewer",
@@ -16,6 +14,7 @@ const globalKeyMap = keyMapWithGroup({
             name: "Area Highlight Mode",
             description: "Toggle area higlight mode",
             sequences: ["a"],
+            priority: 1,
         },
     },
 });

--- a/apps/doc/src/toolbar/AreaHighlightModeToggle.tsx
+++ b/apps/doc/src/toolbar/AreaHighlightModeToggle.tsx
@@ -40,7 +40,7 @@ export const AreaHighlightModeToggle: React.FC = () => {
             <StandardToggleButton
                 onClick={toggleAreaHighlightMode}
                 active={areaHighlightMode}
-                tooltip="Area highlight mode"
+                tooltip="Area highlight mode (a)"
             >
                 <PhotoSizeSelectLargeIcon/>
             </StandardToggleButton>

--- a/apps/doc/src/toolbar/DocViewerToolbar.tsx
+++ b/apps/doc/src/toolbar/DocViewerToolbar.tsx
@@ -27,9 +27,9 @@ import {deepMemo} from "../../../../web/js/react/ReactUtils";
 import {DockLayoutToggleButton} from "../../../../web/js/ui/doc_layout/DockLayoutToggleButton";
 import {ZenModeActiveContainer} from "../../../../web/js/mui/ZenModeActiveContainer";
 import {ZenModeButton} from "./ZenModeButton";
-import {TextHighlightTrigger} from "./TextHighlightTrigger";
 import {AreaHighlightModeToggle} from "./AreaHighlightModeToggle";
 import {useAnnotationPopupBarEnabled} from "../annotations/annotation_popup/AnnotationPopup";
+import {TextHighlightModeToggle} from "./TextHighlightModeToggle";
 
 const getScaleLevelTuple = (scale: ScaleLevel) => (
     arrayStream(ScaleLevelTuples)
@@ -164,7 +164,7 @@ export const DocViewerToolbar = deepMemo(function DocViewerToolbar() {
 
                             <MUIButtonBar>
 
-                                {newAnnotationBarEnabled && <TextHighlightTrigger />}
+                                {newAnnotationBarEnabled && <TextHighlightModeToggle />}
 
                                 <AreaHighlightModeToggle />
 

--- a/apps/doc/src/toolbar/TextHighlightModeToggle.tsx
+++ b/apps/doc/src/toolbar/TextHighlightModeToggle.tsx
@@ -8,6 +8,7 @@ import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import {useDocViewerCallbacks, useDocViewerStore} from "../DocViewerStore";
 import {GlobalKeyboardShortcuts, keyMapWithGroup} from "../../../../web/js/keyboard_shortcuts/GlobalKeyboardShortcuts";
 import {useRefWithUpdates} from "../../../../web/js/hooks/ReactHooks";
+import {usePersistentRouteContext} from "../../../../web/js/apps/repository/PersistentRoute";
 
 type IUseStylesProps = {
     textHighlightColor?: ColorStr;
@@ -34,12 +35,14 @@ const globalKeyMap = keyMapWithGroup({
             name: "Text Highlight Mode",
             description: "Toggle text highlight mode",
             sequences: ["v"],
+            priority: 1,
         },
     }
 });
 
-export const TextHighlightTrigger: React.FC = () => {
+export const TextHighlightModeToggle: React.FC = () => {
     const theme = useTheme();
+    const {active} = usePersistentRouteContext();
     const {textHighlightColor} = useDocViewerStore(["textHighlightColor"]);
     const [selectedColor, setSelectedColor] = React.useState<ColorStr>(MAIN_HIGHLIGHT_COLORS[0]);
     const {setTextHighlightColor} = useDocViewerCallbacks();
@@ -103,9 +106,11 @@ export const TextHighlightTrigger: React.FC = () => {
                     </Grow>
                 )}
             </Popper>
-            <GlobalKeyboardShortcuts
-                keyMap={globalKeyMap}
-                handlerMap={shortcutHandlers}/>
+            {active && 
+                <GlobalKeyboardShortcuts
+                    keyMap={globalKeyMap}
+                    handlerMap={shortcutHandlers}/>
+            }
         </>
     );
 };

--- a/apps/doc/src/toolbar/TextHighlightModeToggle.tsx
+++ b/apps/doc/src/toolbar/TextHighlightModeToggle.tsx
@@ -79,7 +79,7 @@ export const TextHighlightModeToggle: React.FC = () => {
     return (
         <>
             <div ref={anchorRef} className={classes.root}>
-                <StandardIconButton tooltip="Text highlight mode" onClick={handleClick.current}>
+                <StandardIconButton tooltip="Text highlight mode (v)" onClick={handleClick.current}>
                     <PaletteIcon className={classes.triggerIcon}/>
                 </StandardIconButton>
                 <ArrowDropDownIcon className={classes.dropdown} onClick={handleToggle} />

--- a/web/js/hotkeys/ActiveKeyboardShortcutsTable.tsx
+++ b/web/js/hotkeys/ActiveKeyboardShortcutsTable.tsx
@@ -1,6 +1,7 @@
 import {
     IBaseKeyboardShortcut,
     IKeyboardShortcutWithHandler,
+    ShortcutEntry,
 } from "../keyboard_shortcuts/KeyboardShortcutsStore";
 import React from "react";
 import Table from "@material-ui/core/Table";
@@ -12,7 +13,7 @@ import {ArrayListMultimap} from "polar-shared/src/util/Multimap";
 import useTheme from "@material-ui/core/styles/useTheme";
 
 interface IProps {
-    readonly shortcuts: {[binding: string]: IKeyboardShortcutWithHandler};
+    readonly shortcuts: {[binding: string]: ShortcutEntry};
 }
 
 export const ActiveKeyboardShortcutsTable = (props: IProps) => {
@@ -23,7 +24,7 @@ export const ActiveKeyboardShortcutsTable = (props: IProps) => {
 
         const multimap = new ArrayListMultimap<string, IKeyboardShortcutWithHandler>();
 
-        for (const shortcut of Object.values(shortcuts)) {
+        for (const {active: shortcut} of Object.values(shortcuts)) {
             multimap.put(shortcut.group || '', shortcut);
         }
 

--- a/web/js/hotkeys/ActiveKeyboardShortcutsTable2.tsx
+++ b/web/js/hotkeys/ActiveKeyboardShortcutsTable2.tsx
@@ -29,6 +29,7 @@ export const ActiveKeyboardShortcutsTable2 = React.memo((props: ActiveKeyboardSh
     const classes = useStyles();
 
     const filtered = Object.values(shortcuts)
+        .map(x => x.active)
         .filter(shortcut => filter === undefined || shortcut.name.toLowerCase().indexOf(filter.toLowerCase()) !== -1);
 
     const handleKeyDown = React.useCallback((event: React.KeyboardEvent) => {

--- a/web/js/keyboard_shortcuts/KeyboardShortcuts.tsx
+++ b/web/js/keyboard_shortcuts/KeyboardShortcuts.tsx
@@ -237,6 +237,7 @@ export const KeyboardShortcuts = deepMemo(function KeyboardShortcuts() {
         }
 
         return arrayStream(Object.values(shortcutsRef.current))
+            .map(x => x.active)
             .flatMap(toKeyToHandler)
             .collect();
 

--- a/web/js/ui/ColorMenu.tsx
+++ b/web/js/ui/ColorMenu.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import clsx from "clsx";
-import {createStyles, IconButton, makeStyles} from "@material-ui/core";
+import {createStyles, fade, IconButton, makeStyles} from "@material-ui/core";
 import {ColorStr} from "./colors/ColorSelectorBox";
 import PaletteIcon from "@material-ui/icons/Palette";
 
@@ -24,39 +24,57 @@ export const MAIN_HIGHLIGHT_COLORS: ReadonlyArray<ColorStr> = [
     "#B02F2F",
 ];
 
-const useStyles = makeStyles(() =>
+const useStyles = makeStyles((theme) =>
     createStyles({
         root: {
             display: "grid",
-            gridTemplateColumns: "repeat(5, 1fr)",
+            gridTemplateRows: "repeat(3, 1fr)",
+            gridAutoFlow: "column",
             padding: 6,
+        },
+        iconButton: {
+            padding: 0,
+            "&.selected": {
+                backgroundColor: fade(theme.palette.action.active, theme.palette.action.hoverOpacity),
+            },
         },
         item: {
             padding: 6,
             cursor: "pointer",
-        }
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+        },
+        shortcutHint: {
+            marginLeft: 2,
+        },
     }),
 );
 
 type IColorMenuProps = {
-    selected?: ColorStr;
     onChange: (color: ColorStr) => void;
+    selected?: ColorStr;
+    withHints?: boolean;
+    hintLimit?: number;
 };
 
-export const ColorMenu = React.forwardRef<HTMLDivElement, IColorMenuProps>(({ selected, onChange }, ref) => {
+export const ColorMenu = React.forwardRef<HTMLDivElement, IColorMenuProps>((props, ref) => {
     const classes = useStyles();
+    const {selected, onChange, withHints = false, hintLimit = 6} = props;
 
     return (
         <div ref={ref} className={classes.root}>
-            {MAIN_HIGHLIGHT_COLORS.map(color => (
-                <IconButton
-                    className={clsx(classes.item, { selected: selected === color })}
-                    disableRipple
-                    key={color}
-                    onClick={() => onChange(color)}
-                >
-                    { <PaletteIcon style={{ color, display: "block" }} /> }
-                </IconButton>
+            {MAIN_HIGHLIGHT_COLORS.map((color, i) => (
+                <div className={classes.item} key={color}>
+                    <IconButton
+                        className={clsx(classes.iconButton, { selected: selected === color })}
+                        disableRipple
+                        onClick={() => onChange(color)}
+                    >
+                        { <PaletteIcon style={{ color, display: "block" }} /> }
+                    </IconButton>
+                    { withHints && i < hintLimit && <span className={classes.shortcutHint}>{i + 1}</span> }
+                </div>
             ))}
         </div>
     );

--- a/web/js/ui/popup/ActiveSelections.ts
+++ b/web/js/ui/popup/ActiveSelections.ts
@@ -63,10 +63,6 @@ export class ActiveSelections {
                         return;
                     }
 
-                    if (activeSelection) {
-                        handleDestroyedSelection();
-                    }
-
                     if (hasActiveTextSelection) {
 
                         const mouseDirection: MouseDirection = point.y - originPoint!.y < 0 ? 'up' : 'down';


### PR DESCRIPTION
## Changelog:
- Add shortcut hints to the tooltip of each action.
- Unregister the text highlight mode keyboard shortcut if the doc isn't visible (related to PersistentRoute).
- Add shortcut hints to the color menu.
- Allow changing the color of an existing highlight using shortcuts (1-5).
- Fix positioning issues.
- Fix bug where it's impossible to hide the bar after clicking on an existing annotation.